### PR TITLE
Added new KernelPatchVersion

### DIFF
--- a/.github/workflows/image-master.yaml
+++ b/.github/workflows/image-master.yaml
@@ -1,0 +1,33 @@
+name: image-master
+
+on: 
+  pull_request:
+    types: [ closed ]
+  workflow_dispatch:
+
+jobs: 
+  merge_job:
+    if: github.event.pull_request.merged == true
+    name: build-master
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+    - uses: actions/checkout@v2
+      with: 
+        ref: "master"
+
+    - name: add go path
+      run: echo '~/go/bin' >> "$GITHUB_PATH"
+
+    - name: TAG=master make local-image-build 
+      run:  TAG=master make local-image-build
+    
+    - name: make local-image-push
+      run: make local-image-push
+  
+  close_job:
+    # this job will only run if the PR has been closed without being merged
+    if: github.event.pull_request.merged == false
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        echo PR #${{ github.event.number }} has been closed without being merged

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,9 +1,6 @@
 name: image
 
 on: 
-  push:
-    paths-ignore:
-      - "**/README.md"
   pull_request:
     paths-ignore:
       - "**/README.md"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,6 @@
 name: lint
 
 on: 
-  push:
-    paths-ignore:
-      - "**/README.md"
   pull_request:
     paths-ignore:
       - "**/README.md"

--- a/.github/workflows/openshift.yaml
+++ b/.github/workflows/openshift.yaml
@@ -1,9 +1,6 @@
 name: openshift
 
 on: 
-  push:
-    paths-ignore:
-      - "**/README.md"
   pull_request:
     paths-ignore:
       - "**/README.md"
@@ -15,18 +12,18 @@ jobs:
     name: test-e2e
     runs-on: ubuntu-latest
     steps:
-    - name: wait for build to succeed
-      uses: fountainhead/action-wait-for-check@v1.0.0
-      id: wait-for-build
-      with:
-        intervalSeconds: 15
-        token: ${{ secrets.GITHUB_TOKEN }}
-        checkName: build
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+#    - name: wait for build to succeed
+#      uses: fountainhead/action-wait-for-check@v1.0.0
+#      id: wait-for-build
+#      with:
+#        intervalSeconds: 15
+#        token: ${{ secrets.GITHUB_TOKEN }}
+#       checkName: build
+#       ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-    - name: check for successfull build
-      if: steps.wait-for-build.outputs.conclusion != 'success'
-      run: exit 1
+#    - name: check for successfull build
+#      if: steps.wait-for-build.outputs.conclusion != 'success'
+#      run: exit 1
 
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/openshift.yaml
+++ b/.github/workflows/openshift.yaml
@@ -12,25 +12,26 @@ jobs:
     name: test-e2e
     runs-on: ubuntu-latest
     steps:
-#    - name: wait for build to succeed
-#      uses: fountainhead/action-wait-for-check@v1.0.0
-#      id: wait-for-build
-#      with:
-#        intervalSeconds: 15
-#        token: ${{ secrets.GITHUB_TOKEN }}
-#       checkName: build
-#       ref: ${{ github.event.pull_request.head.sha || github.sha }}
+    - name: wait for build to succeed
+      uses: fountainhead/action-wait-for-check@v1.0.0
+      id: wait-for-build
+      with:
+        intervalSeconds: 15
+        token: ${{ secrets.GITHUB_TOKEN }}
+        checkName: build
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-#    - name: check for successfull build
-#      if: steps.wait-for-build.outputs.conclusion != 'success'
-#      run: exit 1
+    - name: check for successfull build
+      if: steps.wait-for-build.outputs.conclusion != 'success'
+      run: exit 1
 
     - name: checkout
       uses: actions/checkout@v2
-    - run: |
+
+    - name: get correct image tag  
+      run: |
         GIT_PR_SHA=${{github.event.pull_request.head.sha}}
         echo TAG=pr-${GIT_PR_SHA:0:10} >> $GITHUB_ENV
-
 
     - name: add go path
       run: echo '~/go/bin' >> "$GITHUB_PATH"
@@ -48,10 +49,10 @@ jobs:
       run: make undeploy
 
     - name: TAG=${{ env.TAG }} make go-deploy-manifests
-    - run:  TAG=${{ env.TAG }} make go-deploy-manifests
+      run:  TAG=${{ env.TAG }} make go-deploy-manifests
 
     - name: make test-e2e
       run: make test-e2e
   
     - name: make go-undeploy-manifests
-    - run: make go-undeploy-manifests
+      run: make go-undeploy-manifests

--- a/.github/workflows/openshift.yaml
+++ b/.github/workflows/openshift.yaml
@@ -16,7 +16,7 @@ jobs:
       uses: fountainhead/action-wait-for-check@v1.0.0
       id: wait-for-build
       with:
-        intervalSeconds: 15
+        intervalSeconds: 30
         token: ${{ secrets.GITHUB_TOKEN }}
         checkName: build
         ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,9 +1,6 @@
 name: unit
 
 on: 
-  push:
-    paths-ignore:
-      - "**/README.md"
   pull_request:
     paths-ignore:
       - "**/README.md"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,9 +1,6 @@
 name: verify
 
 on: 
-  push:
-    paths-ignore:
-      - "**/README.md"
   pull_request:
     paths-ignore:
       - "**/README.md"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift-psap/special-resource-operator
-  newTag: add-metrics
+  newTag: kernel-short-version

--- a/config/manifests/bases/special-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/special-resource-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '["apiVersion":"sro.openshift.io/v1beta1","kind":"SpecialResource","metadata":{"name":"simple-kmod"},"spec":{"namespace":"simple-kmod","configuration":[{"name":"KMOD_NAMES","value":["simple-kmod","simple-procfs-kmod"]}],"driverContainer":{"source":{"git":{"ref":"master","uri":"https://github.com/openshift-psap/kvc-simple-kmod.git"}},"buildArgs":[{"name":"KVER","value":"{{.KernelVersion}}"},{"name":"KMODVER","value":"SRO"}]},"dependsOn":[{"name":"driver-container-base","imageReference":"true"}]}}]'
+    alm-examples: '["apiVersion":"sro.openshift.io/v1beta1","kind":"SpecialResource","metadata":{"name":"simple-kmod"},"spec":{"namespace":"simple-kmod","configuration":[{"name":"KMOD_NAMES","value":["simple-kmod","simple-procfs-kmod"]}],"driverContainer":{"source":{"git":{"ref":"master","uri":"https://github.com/openshift-psap/kvc-simple-kmod.git"}},"buildArgs":[{"name":"KVER","value":"{{.KernelFullVersion}}"},{"name":"KMODVER","value":"SRO"}]},"dependsOn":[{"name":"driver-container-base","imageReference":"true"}]}}]'
     capabilities: Basic Install
     description: The special resource operator is an orchestrator for resources in a cluster required to deploy special hardware and software. Examples include hardware accelerators or software defined storage, where extra management or kernel modules are needed.
     operators.operatorframework.io/builder: operator-sdk-v1.2.0

--- a/config/recipes/lustre-client/0000-lustre-client-cr.yaml
+++ b/config/recipes/lustre-client/0000-lustre-client-cr.yaml
@@ -12,7 +12,7 @@ spec:
   driverContainer:
     buildArgs:
       - name: "KVER"
-        value: "{{.KernelVersion}}"
+        value: "{{.KernelFullVersion}}"
       - name: "RELEASEVER"
         value: "{{.OperatingSystemDecimal}}"
 

--- a/config/recipes/lustre-client/manifests/0000-buildconfig.yaml
+++ b/config/recipes/lustre-client/manifests/0000-buildconfig.yaml
@@ -25,7 +25,7 @@ spec:
     - type: "ImageChange"
   source:
     dockerfile: |
-      FROM image-registry.openshift-image-registry.svc:5000/driver-container-base/driver-container-base:v{{.KernelVersion}}
+      FROM image-registry.openshift-image-registry.svc:5000/driver-container-base/driver-container-base:v{{.KernelFullVersion}}
       MAINTAINER "coreos@lists.fedoraproject.org"
 
       ARG RELEASEVER
@@ -43,7 +43,7 @@ spec:
     dockerStrategy:
       from:
         kind: "ImageStreamTag"
-        name: "driver-container-base:v{{.KernelVersion}}"
+        name: "driver-container-base:v{{.KernelFullVersion}}"
         namespace: "driver-container-base"
       buildArgs: 
         {{ range .SpecialResource.Spec.DriverContainer.BuildArgs }}
@@ -53,4 +53,4 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelVersion}}
+      name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}

--- a/config/recipes/lustre-client/manifests/1000-driver-container.yaml
+++ b/config/recipes/lustre-client/manifests/1000-driver-container.yaml
@@ -141,7 +141,7 @@ spec:
       serviceAccountName: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
 #      hostPID: true
       containers:
-      - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Spec.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelVersion}}
+      - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Spec.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}
         imagePullPolicy: Always
         name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
         command: ["/bin/entrypoint.sh"]
@@ -173,4 +173,4 @@ spec:
             name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}-entrypoint
       nodeSelector:
         node-role.kubernetes.io/worker: ""
-        feature.node.kubernetes.io/kernel-version.full: "{{.KernelVersion}}"
+        feature.node.kubernetes.io/kernel-version.full: "{{.KernelFullVersion}}"

--- a/config/recipes/mlnx-rdma-shared/manifests/gpudirect/1000-state-driver.yaml
+++ b/config/recipes/mlnx-rdma-shared/manifests/gpudirect/1000-state-driver.yaml
@@ -186,4 +186,4 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
         {{.SpecialResource.Spec.Node.Selector}}: "true"
-        feature.node.kubernetes.io/kernel-version.full: "{{.KernelVersion}}"
+        feature.node.kubernetes.io/kernel-version.full: "{{.KernelFullVersion}}"

--- a/config/recipes/mlnx-rdma-shared/manifests/mofed/0000-state-driver-buildconfig.yaml
+++ b/config/recipes/mlnx-rdma-shared/manifests/mofed/0000-state-driver-buildconfig.yaml
@@ -37,4 +37,4 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelVersion}}
+      name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}

--- a/config/recipes/mlnx-rdma-shared/manifests/mofed/1000-state-driver.yaml
+++ b/config/recipes/mlnx-rdma-shared/manifests/mofed/1000-state-driver.yaml
@@ -155,7 +155,7 @@ spec:
       serviceAccountName: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
       hostPID: true
       containers:
-      - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelVersion}}
+      - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}
         imagePullPolicy: Always
         name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
         command: ["/bin/entrypoint.sh"]
@@ -182,4 +182,4 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
         {{.SpecialResource.Spec.Node.Selector}}: "true"
-        feature.node.kubernetes.io/kernel-version.full: "{{.KernelVersion}}"
+        feature.node.kubernetes.io/kernel-version.full: "{{.KernelFullVersion}}"

--- a/config/recipes/nvidia-gpu/manifests/0000-state-driver-buildconfig.yaml
+++ b/config/recipes/nvidia-gpu/manifests/0000-state-driver-buildconfig.yaml
@@ -103,7 +103,7 @@ spec:
     dockerStrategy:
       from:
         kind: "ImageStreamTag"
-        name: "driver-container-base:v{{.KernelVersion}}"
+        name: "driver-container-base:v{{.KernelFullVersion}}"
         namespace: "driver-container-base"
       buildArgs:
         {{ range .SpecialResource.Spec.DriverContainer.BuildArgs }}
@@ -113,4 +113,4 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelVersion}}
+      name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}

--- a/config/recipes/nvidia-gpu/manifests/1000-state-driver.yaml
+++ b/config/recipes/nvidia-gpu/manifests/1000-state-driver.yaml
@@ -78,7 +78,7 @@ spec:
       serviceAccountName: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
       hostPID: true
       containers:
-      - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Spec.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelVersion}}
+      - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Spec.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}
         imagePullPolicy: Always
         name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
         command: ["/bin/entrypoint.sh"]
@@ -117,4 +117,4 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
         {{.SpecialResource.Spec.Node.Selector}}: "true"
-        feature.node.kubernetes.io/kernel-version.full: "{{.KernelVersion}}"
+        feature.node.kubernetes.io/kernel-version.full: "{{.KernelFullVersion}}"

--- a/config/recipes/nvidia-vran/manifests/gdrdrv/1000-state-driver.yaml
+++ b/config/recipes/nvidia-vran/manifests/gdrdrv/1000-state-driver.yaml
@@ -205,4 +205,4 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
         {{.SpecialResource.Spec.Node.Selector}}: "true"
-        feature.node.kubernetes.io/kernel-version.full: "{{.KernelVersion}}"
+        feature.node.kubernetes.io/kernel-version.full: "{{.KernelFullVersion}}"

--- a/config/recipes/nvidia-vran/manifests/gpudirect/1000-state-driver.yaml
+++ b/config/recipes/nvidia-vran/manifests/gpudirect/1000-state-driver.yaml
@@ -191,4 +191,4 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
         {{.SpecialResource.Spec.Node.Selector}}: "true"
-        feature.node.kubernetes.io/kernel-version.full: "{{.KernelVersion}}"
+        feature.node.kubernetes.io/kernel-version.full: "{{.KernelFullVersion}}"

--- a/config/recipes/nvidia-vran/manifests/mofed/0000-state-driver-buildconfig.yaml
+++ b/config/recipes/nvidia-vran/manifests/mofed/0000-state-driver-buildconfig.yaml
@@ -37,4 +37,4 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelVersion}}
+      name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}

--- a/config/recipes/nvidia-vran/manifests/mofed/1000-state-driver.yaml
+++ b/config/recipes/nvidia-vran/manifests/mofed/1000-state-driver.yaml
@@ -155,7 +155,7 @@ spec:
       serviceAccountName: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
       hostNetwork: true
       containers:
-      - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelVersion}}
+      - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}
         imagePullPolicy: Always
         name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
         command: ["/bin/entrypoint.sh"]
@@ -192,4 +192,4 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
         {{.SpecialResource.Spec.Node.Selector}}: "true"
-        feature.node.kubernetes.io/kernel-version.full: "{{.KernelVersion}}"
+        feature.node.kubernetes.io/kernel-version.full: "{{.KernelFullVersion}}"

--- a/config/recipes/simple-kmod/0000-simple-kmod-cr.yaml
+++ b/config/recipes/simple-kmod/0000-simple-kmod-cr.yaml
@@ -14,7 +14,7 @@ spec:
         uri: "https://github.com/openshift-psap/kvc-simple-kmod.git"
     buildArgs:
       - name: "KVER"
-        value: "{{.KernelVersion}}"
+        value: "{{.KernelFullVersion}}"
       - name: "KMODVER"
         value: "SRO"
 

--- a/config/recipes/simple-kmod/manifests/0000-buildconfig..yaml
+++ b/config/recipes/simple-kmod/manifests/0000-buildconfig..yaml
@@ -32,7 +32,7 @@ spec:
       dockerfilePath: Dockerfile.SRO
       from:
         kind: "ImageStreamTag"
-        name: "driver-container-base:v{{.KernelVersion}}"
+        name: "driver-container-base:v{{.KernelFullVersion}}"
         namespace: "driver-container-base"
       buildArgs: 
         {{ range .SpecialResource.Spec.DriverContainer.BuildArgs }}
@@ -42,4 +42,4 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelVersion}}
+      name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}

--- a/config/recipes/simple-kmod/manifests/1000-driver-container.yaml
+++ b/config/recipes/simple-kmod/manifests/1000-driver-container.yaml
@@ -59,7 +59,7 @@ spec:
       serviceAccount: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
       serviceAccountName: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
       containers:
-      - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Spec.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelVersion}}
+      - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Spec.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}
         imagePullPolicy: Always
         name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
         command: ["/sbin/init"]
@@ -67,4 +67,4 @@ spec:
           privileged: true
       nodeSelector:
         node-role.kubernetes.io/worker: ""
-        feature.node.kubernetes.io/kernel-version.full: "{{.KernelVersion}}"
+        feature.node.kubernetes.io/kernel-version.full: "{{.KernelFullVersion}}"

--- a/config/samples/sro_v1beta1_specialresource.yaml
+++ b/config/samples/sro_v1beta1_specialresource.yaml
@@ -14,7 +14,7 @@ spec:
         uri: "https://github.com/openshift-psap/kvc-simple-kmod.git"
     buildArgs:
       - name: "KVER"
-        value: "{{.KernelVersion}}"
+        value: "{{.KernelFullVersion}}"
       - name: "KMODVER"
         value: "SRO"
 

--- a/manifests/0012_deployment_special-resource-controller-manager.yaml
+++ b/manifests/0012_deployment_special-resource-controller-manager.yaml
@@ -52,7 +52,7 @@ spec:
               fieldPath: metadata.namespace
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot
-        image: quay.io/openshift-psap/special-resource-operator:add-metrics
+        image: quay.io/openshift-psap/special-resource-operator:kernel-short-version
         imagePullPolicy: Always
         name: manager
         resources:


### PR DESCRIPTION
Using w.xx.y-zzz and looking at 4.4.0-45 we can say:
w = Kernel Version = 4
xx= Major Revision = 4
y = Minor Revision = 0
zzz=Patch number = 45

This will add a new runtime variable KernelPatchVersion 
```
INFO	driver-container-base  	Runtime Information	{"KernelFullVersion": "4.18.0-193.28.1.el8_2.x86_64"}
INFO	driver-container-base  	Runtime Information	{"KernelPatchVersion": "4.18.0-193"}
```