### PR TITLE
Add relatedObjects to ClusterOperator for must-gather

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -129,7 +129,8 @@ func (r *SpecialResourceReconciler) clusterOperatorUpdateRelatedObjects() error 
 	return nil
 }
 
-// ReportSpecialResourcesStatus Depending on what error we're getting from the
+// ReportSpecialResourcesStatus 
+// Depending on what error we're getting from the
 // reconciliation loop we're updating the status
 // nil -> All things good and default conditions can be applied
 func ReportSpecialResourcesStatus(r *SpecialResourceReconciler, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
In status.go added getRelatedObjects() function to get the relevant relatedObjects for must-gather, and use it to update relatedObjects field of the clusterOperator in clusterOperatorStatusReconcile().

Currently relatedObjects will include:
- namespace openshift-special-resource-operator
- all specialresource objects
- namespace for each specialresource (except preamble since spec.namespace field is empty)