### PR TITLE
lustre-client and runtime.go updates

### DIFF
--- a/config/recipes/lustre-client/0000-lustre-client-cr.yaml
+++ b/config/recipes/lustre-client/0000-lustre-client-cr.yaml
@@ -16,3 +16,6 @@ spec:
       - name: "RELEASEVER"
         value: "{{.OperatingSystemDecimal}}"
 
+  dependsOn:
+    - name: "driver-container-base"
+      imageReference: "true"

--- a/config/recipes/lustre-client/manifests/1100-lustre-csi-secret.yaml
+++ b/config/recipes/lustre-client/manifests/1100-lustre-csi-secret.yaml
@@ -4,5 +4,5 @@ metadata:
   name: aws-secret
   namespace: kube-system
 stringData:
-  {{(index .SpecialResource.Spec.Configuration 0).Name}}: "{{(index .SpecialResource.Spec.Configuration 0).Value[0]}}}"
-  {{(index .SpecialResource.Spec.Configuration 1).Name}}: "{{(index .SpecialResource.Spec.Configuration 1).Value[0]}}"
+  {{(index .SpecialResource.Spec.Configuration 0).Name}}: "{{(index (index .SpecialResource.Spec.Configuration 0).Value 0)}}"
+  {{(index .SpecialResource.Spec.Configuration 1).Name}}: "{{(index (index .SpecialResource.Spec.Configuration 1).Value 0)}}"


### PR DESCRIPTION
This PR adds some fixes to the lustre-client recipe:
 - Adds driver-container-base as a dependency
 - Fixes template in 1100-lustre-csi-secret

As well as another bug:
 - Adds function to runtime.go to wait for 2 seconds up to 3 times for secrets to be created, to avoid exiting on error when reconciling hardware states. This was causing a operator pod restart in some instances.

There is a remaining issue that the lustre-client kmod is not always available for the correct kernel version for RHCOS which needs to be investigated further.