### PR TITLE
WIP: Fixed typo in comment in resources.go

### DIFF
--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -350,7 +350,7 @@ func createFromYAML(yamlFile []byte, r *SpecialResourceReconciler, namespace str
 		err = CRUD(obj, r)
 		exit.OnError(errs.Wrap(err, "CRUD exited non-zero"))
 
-		// Callbacks after CRUD will wait for ressource and check status
+		// Callbacks after CRUD will wait for resource and check status
 		if err := afterCRUDhooks(obj, r); err != nil {
 			return errs.Wrap(err, "After CRUD hooks failed")
 		}

--- a/manifests/0012_deployment_special-resource-controller-manager.yaml
+++ b/manifests/0012_deployment_special-resource-controller-manager.yaml
@@ -81,5 +81,3 @@ spec:
       - name: special-resource-operator-tls
         secret:
           secretName: special-resource-operator-tls
-
-

--- a/manifests/0012_deployment_special-resource-controller-manager.yaml
+++ b/manifests/0012_deployment_special-resource-controller-manager.yaml
@@ -81,3 +81,5 @@ spec:
       - name: special-resource-operator-tls
         secret:
           secretName: special-resource-operator-tls
+
+

--- a/manifests/0012_deployment_special-resource-controller-manager.yaml
+++ b/manifests/0012_deployment_special-resource-controller-manager.yaml
@@ -66,8 +66,6 @@ spec:
         name: manager
         resources:
           limits:
-            cpu: 200m
-            memory: 100Mi
           requests:
             cpu: 200m
             memory: 100Mi


### PR DESCRIPTION
(For demo of CI)
- Fixes a minor typo in controllers/resources.go
- Makes a bad change to manifests/0012... to test kube-lint