### PR TITLE
Update lustre-client

### DIFF
--- a/config/recipes/lustre-client/0000-lustre-client-cr.yaml
+++ b/config/recipes/lustre-client/0000-lustre-client-cr.yaml
@@ -10,11 +10,15 @@ spec:
     - name: "access_key"
       value: ["AWS_SECRET_ACCESS_KEY"]
   driverContainer:
+    source:
+      git:
+        ref: "master"
+        uri: "https://github.com/openshift-psap/kvc-lustre-client.git"
     buildArgs:
       - name: "KVER"
         value: "{{.KernelFullVersion}}"
-      - name: "RELEASEVER"
-        value: "{{.OperatingSystemDecimal}}"
+      - name: "KMODVER"
+        value: "SRO"
 
   dependsOn:
     - name: "driver-container-base"

--- a/config/recipes/lustre-client/manifests/0000-buildconfig.yaml
+++ b/config/recipes/lustre-client/manifests/0000-buildconfig.yaml
@@ -18,29 +18,18 @@ metadata:
 spec:
   nodeSelector:
     node-role.kubernetes.io/worker: ""
-#    {{.SpecialResource.Spec.Node.Selector}}: "true"
   runPolicy: "Serial"
   triggers:
     - type: "ConfigChange"
     - type: "ImageChange"
   source:
-    dockerfile: |
-      FROM image-registry.openshift-image-registry.svc:5000/driver-container-base/driver-container-base:v{{.KernelFullVersion}}
-      MAINTAINER "coreos@lists.fedoraproject.org"
-
-      ARG RELEASEVER
-
-      RUN yum -y install --releasever=${RELEASEVER} wget git --setopt=install_weak_deps=False --best
-
-      
-      RUN wget https://fsx-lustre-client-repo-public-keys.s3.amazonaws.com/fsx-rpm-public-key.asc -O /tmp/fsx-rpm-public-key.asc \
-          && rpm --import /tmp/fsx-rpm-public-key.asc \
-          && wget https://fsx-lustre-client-repo.s3.amazonaws.com/el/8/fsx-lustre-client.repo -O /etc/yum.repos.d/aws-fsx.repo
-
-      RUN yum -y install --releasever=${RELEASEVER} kmod-lustre-client lustre-client --setopt=install_weak_deps=False --best
-      
+    git:
+      ref: {{.SpecialResource.Spec.DriverContainer.Source.Git.Ref}}
+      uri: {{.SpecialResource.Spec.DriverContainer.Source.Git.Uri}}
+    type: Git 
   strategy:
     dockerStrategy:
+      dockerfilePath: Dockerfile.SRO
       from:
         kind: "ImageStreamTag"
         name: "driver-container-base:v{{.KernelFullVersion}}"

--- a/config/recipes/lustre-client/manifests/1000-driver-container.yaml
+++ b/config/recipes/lustre-client/manifests/1000-driver-container.yaml
@@ -49,6 +49,7 @@ data:
         lustre_rmmod
     }
 
+    # weak-modules enforces dracut dependency even when using --no-initramfs, a BZ has been opened and these two lines should be later not needed
     touch /usr/bin/dracut
     chmod +x /usr/bin/dracut
     find /lib/modules/*/extra/lustre-client | grep .ko | weak-modules --add-modules --verbose --no-initramfs

--- a/config/recipes/lustre-client/manifests/1000-driver-container.yaml
+++ b/config/recipes/lustre-client/manifests/1000-driver-container.yaml
@@ -49,6 +49,10 @@ data:
         lustre_rmmod
     }
 
+    touch /usr/bin/dracut
+    chmod +x /usr/bin/dracut
+    find /lib/modules/*/extra/lustre-client | grep .ko | weak-modules --add-modules --verbose --no-initramfs
+
     modprobe -v lnet
     modprobe -v ksocklnd
     modprobe -v mgc
@@ -58,10 +62,10 @@ data:
 
     mkdir -p /mnt/fsx
 
-    trap "echo 'Caught signal'; exit 1" HUP INT QUIT PIPE TERM
-    trap "unmount" EXIT
+    sleep infinity & PID=$!
+    trap "kill $PID; unmount" HUP INT QUIT PIPE TERM EXIT
+    wait
 
-    sleep infinity
 ---
 # Please edit the object below. Lines beginning with a '#' will be ignored,
 # and an empty file will abort the edit. If an error occurs while saving this file will be

--- a/config/recipes/lustre-client/manifests/1000-driver-container.yaml
+++ b/config/recipes/lustre-client/manifests/1000-driver-container.yaml
@@ -31,43 +31,6 @@ subjects:
 userNames:
 - system:serviceaccount:{{.SpecialResource.Spec.Namespace}}:{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}-entrypoint
-data:
-  entrypoint.sh: |-
-    #!/bin/bash -x
-
-    unmount() {
-        modprobe -r lustre
-        modprobe -r osc
-        modprobe -r mgc
-        lnetctl lnet unconfigure
-        modprobe -r ksocklnd
-        modprobe -r lnet
-        lustre_rmmod
-    }
-
-    # weak-modules enforces dracut dependency even when using --no-initramfs, a BZ has been opened and these two lines should be later not needed
-    touch /usr/bin/dracut
-    chmod +x /usr/bin/dracut
-    find /lib/modules/*/extra/lustre-client | grep .ko | weak-modules --add-modules --verbose --no-initramfs
-
-    modprobe -v lnet
-    modprobe -v ksocklnd
-    modprobe -v mgc
-    modprobe -v osc
-    lnetctl lnet configure --all
-    modprobe -v lustre
-
-    mkdir -p /mnt/fsx
-
-    sleep infinity & PID=$!
-    trap "kill $PID; unmount" HUP INT QUIT PIPE TERM EXIT
-    wait
-
----
 # Please edit the object below. Lines beginning with a '#' will be ignored,
 # and an empty file will abort the edit. If an error occurs while saving this file will be
 # reopened with the relevant failures.
@@ -149,7 +112,7 @@ spec:
       - image: image-registry.openshift-image-registry.svc:5000/{{.SpecialResource.Spec.Namespace}}/{{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}:v{{.KernelFullVersion}}
         imagePullPolicy: Always
         name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
-        command: ["/bin/entrypoint.sh"]
+        command: ["/sbin/init"]
         securityContext:
           privileged: true
           hostNetwork: true
@@ -158,10 +121,6 @@ spec:
         volumeMounts:
           - name: devices
             mountPath: /dev
-          - name: entrypoint
-            mountPath: /bin/entrypoint.sh
-            readOnly: true
-            subPath: entrypoint.sh
           - name: overlay
             mountPath: /tmp/overlay
             readOnly: true
@@ -172,10 +131,6 @@ spec:
         - name: devices
           hostPath:
             path: /dev
-        - name: entrypoint
-          configMap:
-            defaultMode: 0700
-            name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}-entrypoint
       nodeSelector:
         node-role.kubernetes.io/worker: ""
         feature.node.kubernetes.io/kernel-version.full: "{{.KernelFullVersion}}"


### PR DESCRIPTION
Adds two more changes to the lustre-client recipe
- use weak-modules / weak-updates for when kernel is not an exact match
- Handle sigterm to unload modules