### PR TITLE
Bug fixes: finalizers, e2e tests, runtime.go, status.go

### DIFF
--- a/controllers/runtime.go
+++ b/controllers/runtime.go
@@ -2,13 +2,14 @@ package controllers
 
 import (
 	"context"
-	"strconv"
 	"strings"
 	"time"
 
 	srov1beta1 "github.com/openshift-psap/special-resource-operator/api/v1beta1"
 	"github.com/openshift-psap/special-resource-operator/pkg/exit"
 	"github.com/openshift-psap/special-resource-operator/pkg/warn"
+	"github.com/openshift-psap/special-resource-operator/pkg/osversion"
+
 	"github.com/pkg/errors"
 	errs "github.com/pkg/errors"
 
@@ -182,50 +183,10 @@ func getOperatingSystem() (string, string, string, error) {
 		}
 	}
 
-	return renderOperatingSystem(nodeOSrel, nodeOSmaj, nodeOSmin)
+	return osversion.RenderOperatingSystem(nodeOSrel, nodeOSmaj, nodeOSmin)
 }
 
-func renderOperatingSystem(rel string, maj string, min string) (string, string, string, error) {
 
-	log.Info("OS", "rel", rel)
-	log.Info("OS", "maj", maj)
-	log.Info("OS", "min", min) // this can be empty e.g fedora30
-
-	// rhcos version is the openshift version running need to translate
-	// into rhel major minor version
-	if strings.Compare(rel, "rhcos") == 0 {
-		rel := "rhel"
-
-		num, _ := strconv.Atoi(min)
-
-		if strings.Compare(maj, "4") == 0 && num < 4 {
-			maj := "8"
-			return rel + maj, rel + maj + ".0", maj + ".0", nil
-		}
-
-		if strings.Compare(maj, "4") == 0 && strings.Compare(min, "4") == 0 {
-			maj := "8"
-			return rel + maj, rel + maj + ".1", maj + ".1", nil
-		}
-
-		if strings.Compare(maj, "4") == 0 && num < 7 {
-			maj := "8"
-			return rel + maj, rel + maj + ".2", maj + ".2", nil
-		}
-
-		maj := "8"
-		return rel + maj, rel + maj + ".3", maj + ".3", nil
-	}
-
-	// A Fedora system has no min yet, so if min is empty
-	// return fedora31 and not fedora31.
-	if min == "" {
-		return rel + maj, rel + maj, maj, nil
-	}
-
-	return rel + maj, rel + maj + "." + min, maj + "." + min, nil
-
-}
 
 func getKernelFullVersion() (string, error) {
 

--- a/controllers/runtime.go
+++ b/controllers/runtime.go
@@ -208,13 +208,13 @@ func renderOperatingSystem(rel string, maj string, min string) (string, string, 
 			return rel + maj, rel + maj + ".1", maj + ".1", nil
 		}
 
-		if strings.Compare(maj, "4") == 0 && strings.Compare(min, "5") == 0 {
+		if strings.Compare(maj, "4") == 0 && num < 7 {
 			maj := "8"
 			return rel + maj, rel + maj + ".2", maj + ".2", nil
 		}
 
 		maj := "8"
-		return rel + maj, rel + maj + ".2", maj + ".2", nil
+		return rel + maj, rel + maj + ".3", maj + ".3", nil
 	}
 
 	// A Fedora system has no min yet, so if min is empty

--- a/controllers/runtime.go
+++ b/controllers/runtime.go
@@ -7,8 +7,8 @@ import (
 
 	srov1beta1 "github.com/openshift-psap/special-resource-operator/api/v1beta1"
 	"github.com/openshift-psap/special-resource-operator/pkg/exit"
-	"github.com/openshift-psap/special-resource-operator/pkg/warn"
 	"github.com/openshift-psap/special-resource-operator/pkg/osversion"
+	"github.com/openshift-psap/special-resource-operator/pkg/warn"
 
 	"github.com/pkg/errors"
 	errs "github.com/pkg/errors"
@@ -185,8 +185,6 @@ func getOperatingSystem() (string, string, string, error) {
 
 	return osversion.RenderOperatingSystem(nodeOSrel, nodeOSmaj, nodeOSmin)
 }
-
-
 
 func getKernelFullVersion() (string, error) {
 

--- a/controllers/specialresource.go
+++ b/controllers/specialresource.go
@@ -96,6 +96,15 @@ func SpecialResourcesReconcile(r *SpecialResourceReconciler, req ctrl.Request) (
 			continue
 		}
 
+		// Execute finalization logic if CR is being deleted
+		isMarkedToBeDeleted := r.parent.GetDeletionTimestamp() != nil
+		if isMarkedToBeDeleted {
+			r.specialresource = r.parent
+			log.Info("Marked to be deleted, reconciling finalizer")
+			err = reconcileFinalizers(r)
+			return reconcile.Result{}, err
+		}
+
 		// Only one level dependency support for now
 		for _, r.dependency = range r.parent.Spec.DependsOn {
 
@@ -128,14 +137,6 @@ func SpecialResourcesReconcile(r *SpecialResourceReconciler, req ctrl.Request) (
 		r.specialresource = r.parent
 		log = r.Log.WithName(color.Print(r.specialresource.Name, color.Green))
 		log.Info("Reconciling")
-
-		// Execute finalization logic if CR is being deleted
-		isMarkedToBeDeleted := r.specialresource.GetDeletionTimestamp() != nil
-		if isMarkedToBeDeleted {
-			log.Info("Marked to be deleted, reconciling finalizer")
-			err = reconcileFinalizers(r)
-			return reconcile.Result{}, err
-		}
 
 		// Add a finalizer to CR if it does not already have one
 		if !contains(r.specialresource.GetFinalizers(), specialresourceFinalizer) {

--- a/controllers/specialresource_controller.go
+++ b/controllers/specialresource_controller.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"fmt"
+
 	"github.com/go-logr/logr"
 	srov1beta1 "github.com/openshift-psap/special-resource-operator/api/v1beta1"
 	"github.com/openshift-psap/special-resource-operator/pkg/conditions"
@@ -81,7 +83,8 @@ func (r *SpecialResourceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	// Only if we're successfull we're going to update the status to
 	// Available otherwise retunr the recondile error
 	if res, err = SpecialResourcesStatus(r, req, conds); err != nil {
-		return res, errs.Wrap(err, "Cannot update special resource status")
+		log.Info("Cannot update special resource status", "error", fmt.Sprintf("%v", err))
+		return res, nil
 	}
 
 	return reconcile.Result{}, nil

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -2,12 +2,10 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	srov1beta1 "github.com/openshift-psap/special-resource-operator/api/v1beta1"
 	"github.com/openshift-psap/special-resource-operator/pkg/color"
-	"github.com/openshift-psap/special-resource-operator/pkg/conditions"
 	"github.com/openshift-psap/special-resource-operator/pkg/exit"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -133,22 +131,14 @@ func (r *SpecialResourceReconciler) clusterOperatorUpdateRelatedObjects() error 
 // reconciliation loop we're updating the status
 // nil -> All things good and default conditions can be applied
 func SpecialResourcesStatus(r *SpecialResourceReconciler, req ctrl.Request, cond []configv1.ClusterOperatorStatusCondition) (ctrl.Result, error) {
-
-	newConditions := conditions.NotAvailableProgressingNotDegraded(
-		"Reconciling "+req.Name,
-		"Reconciling "+req.Name,
-		conditions.DegradedDefaultMsg,
-	)
-
 	log = r.Log.WithName(color.Print("status", color.Blue))
 	if err := r.clusterOperatorStatusGetOrCreate(); err != nil {
 		return reconcile.Result{Requeue: true}, errs.Wrap(err, "Cannot get or create ClusterOperator")
 	}
 
 	log.Info("Reconciling ClusterOperator")
-	if err := r.clusterOperatorStatusReconcile(newConditions); err != nil {
-		log.Info("Reconciling ClusterOperator failed", "error", fmt.Sprintf("%v", err))
-		return reconcile.Result{Requeue: true}, nil
+	if err := r.clusterOperatorStatusReconcile(cond); err != nil {
+		return reconcile.Result{Requeue: true}, errs.Wrap(err, "Reconciling ClusterOperator failed")
 	}
 	return reconcile.Result{}, nil
 }

--- a/pkg/osversion/osversion.go
+++ b/pkg/osversion/osversion.go
@@ -1,0 +1,35 @@
+package osversion
+
+import (
+
+)
+
+
+// Given 3 labels from NFD returns the node OS version in 3 formats:
+// <name><major>, <name><major>.<minor>, and <major.minor>
+// For example rhel8, rhel8.2, 8.2
+// If the "rel" is rhcos it returns the rhel version that this rhcos version is based off of.
+// This function will later be replaced as NFD will have separate labels for this information.
+func RenderOperatingSystem(rel string, maj string, min string) (string, string, string, error) {
+	// Usually the nodes will be rhcos nodes and we want to know the rhel version RHCOS is based on
+    if rel == "rhcos" && maj == "4" {
+	rhelMaj := "8"
+	var rhelMin string
+	switch {
+        case min <= "3":
+	    rhelMin = "0"
+        case min == "4":
+            rhelMin = "1"
+        case min <= "6":
+            rhelMin = "2"
+        case min <= "8":
+	    rhelMin = "3"
+        }
+        return "rhel"+rhelMaj, "rhel"+rhelMaj+"."+rhelMin, rhelMaj+"."+rhelMin, nil
+    }
+	// If for example we have fedora nodes with no min version
+	if min == "" {
+		return rel + maj, rel + maj, maj, nil
+	}
+	return rel + maj, rel + maj + "." + min, maj + "." + min, nil
+}

--- a/pkg/osversion/osversion.go
+++ b/pkg/osversion/osversion.go
@@ -1,9 +1,6 @@
 package osversion
 
-import (
-
-)
-
+import ()
 
 // Given 3 labels from NFD returns the node OS version in 3 formats:
 // <name><major>, <name><major>.<minor>, and <major.minor>
@@ -12,24 +9,25 @@ import (
 // This function will later be replaced as NFD will have separate labels for this information.
 func RenderOperatingSystem(rel string, maj string, min string) (string, string, string, error) {
 	// Usually the nodes will be rhcos nodes and we want to know the rhel version RHCOS is based on
-    if rel == "rhcos" && maj == "4" {
-	rhelMaj := "8"
-	var rhelMin string
-	switch {
-        case min <= "3":
-	    rhelMin = "0"
-        case min == "4":
-            rhelMin = "1"
-        case min <= "6":
-            rhelMin = "2"
-        case min <= "8":
-	    rhelMin = "3"
-        }
-        return "rhel"+rhelMaj, "rhel"+rhelMaj+"."+rhelMin, rhelMaj+"."+rhelMin, nil
-    }
+	if rel == "rhcos" && maj == "4" {
+		rhelMaj := "8"
+		var rhelMin string
+		switch {
+		case min <= "3":
+			rhelMin = "0"
+		case min == "4":
+			rhelMin = "1"
+		case min <= "6":
+			rhelMin = "2"
+		case min <= "8":
+			rhelMin = "3"
+		}
+		return "rhel" + rhelMaj, "rhel" + rhelMaj + "." + rhelMin, rhelMaj + "." + rhelMin, nil
+	}
 	// If for example we have fedora nodes with no min version
 	if min == "" {
 		return rel + maj, rel + maj, maj, nil
 	}
 	return rel + maj, rel + maj + "." + min, maj + "." + min, nil
 }
+

--- a/test/e2e/basic/simple-kmod.go
+++ b/test/e2e/basic/simple-kmod.go
@@ -39,9 +39,9 @@ var _ = ginkgo.Describe("[basic][simple-kmod] create and deploy simple-kmod", fu
 		ginkgo.By("Checking if NFD is running, getting kernel, os, ocp versions")
 		var err error
 		nodeKernelFullVersion, nodeOSVersion, nodeOCPVersion, err = GetVersionTriplet(cs)
-		Logf("Info: KernelVersion: " + nodeKernelFullVersion)
-		Logf("Info: OSVersion: " + nodeOSVersion)
-		Logf("Info: OpenShift Version: " + nodeOCPVersion)
+		_, _ = Logf("Info: KernelVersion: " + nodeKernelFullVersion)
+		_, _ = Logf("Info: OSVersion: " + nodeOSVersion)
+		_, _ = Logf("Info: OpenShift Version: " + nodeOCPVersion)
 
 		if err != nil {
 			explain = err.Error()
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("[basic][simple-kmod] create and deploy simple-kmod", fu
 
 		kernelVersion := strings.ReplaceAll(nodeKernelFullVersion, "_", "-")
 		hash64 := hash.FNV64a(nodeOSVersion + "-" + kernelVersion)
-		Logf("Info: hash64 for object names: " + hash64)
+		_, _ = Logf("Info: hash64 for object names: " + hash64)
 
 		buffer, err := ioutil.ReadFile("../../../config/recipes/simple-kmod/0000-simple-kmod-cr.yaml")
 		if err != nil {

--- a/test/e2e/basic/simple-kmod.go
+++ b/test/e2e/basic/simple-kmod.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	"github.com/openshift-psap/special-resource-operator/pkg/hash"
 	"github.com/openshift-psap/special-resource-operator/test/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,8 +29,28 @@ var _ = ginkgo.Describe("[basic][simple-kmod] create and deploy simple-kmod", fu
 
 	var explain string
 
+	var nodeKernelFullVersion string
+	var nodeOSVersion string
+	var nodeOCPVersion string
+
 	// Check that operator deployment has 1 available pod
 	ginkgo.It("Can create driver-container-base and deploy simple-kmod", func() {
+
+		ginkgo.By("Checking if NFD is running, getting kernel, os, ocp versions")
+		var err error
+		nodeKernelFullVersion, nodeOSVersion, nodeOCPVersion, err = GetVersionTriplet(cs)
+		Logf("Info: KernelVersion: " + nodeKernelFullVersion)
+		Logf("Info: OSVersion: " + nodeOSVersion)
+		Logf("Info: OpenShift Version: " + nodeOCPVersion)
+
+		if err != nil {
+			explain = err.Error()
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), explain)
+
+		kernelVersion := strings.ReplaceAll(nodeKernelFullVersion, "_", "-")
+		hash64 := hash.FNV64a(nodeOSVersion + "-" + kernelVersion)
+		Logf("Info: hash64 for object names: " + hash64)
 
 		buffer, err := ioutil.ReadFile("../../../config/recipes/simple-kmod/0000-simple-kmod-cr.yaml")
 		if err != nil {
@@ -49,8 +70,7 @@ var _ = ginkgo.Describe("[basic][simple-kmod] create and deploy simple-kmod", fu
 				return false, nil
 			}
 
-			driverContainerBase, err := cs.Pods("driver-container-base").Get(context.TODO(), "driver-container-base", metav1.GetOptions{})
-
+			driverContainerBase, err := cs.Pods("driver-container-base").Get(context.TODO(), "driver-container-base"+"-"+hash64, metav1.GetOptions{})
 			if err != nil {
 				return false, fmt.Errorf("Couldn't get driver-container-base pod, %v", err)
 			}
@@ -64,6 +84,9 @@ var _ = ginkgo.Describe("[basic][simple-kmod] create and deploy simple-kmod", fu
 
 			return false, nil
 		})
+		if err != nil {
+			explain = err.Error()
+		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), explain)
 
 		ginkgo.By("waiting for simple-kmod daemonset to be ready")
@@ -81,6 +104,9 @@ var _ = ginkgo.Describe("[basic][simple-kmod] create and deploy simple-kmod", fu
 			}
 			return false, nil
 		})
+		if err != nil {
+			explain = err.Error()
+		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), explain)
 
 		// Now check if module is actually running
@@ -95,9 +121,9 @@ var _ = ginkgo.Describe("[basic][simple-kmod] create and deploy simple-kmod", fu
 
 		//get driver container pod on worker node
 		ginkgo.By(fmt.Sprintf("getting a simple-kmod-driver-container Pod running on node %s", node.Name))
-		listOptions := metav1.ListOptions{
+		listOptions := metav1.ListOptions{ //TODO fix
 			FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": node.Name}).String(),
-			LabelSelector: labels.SelectorFromSet(labels.Set{"app": "simple-kmod-driver-container-rhel8"}).String(),
+			LabelSelector: labels.SelectorFromSet(labels.Set{"app": "simple-kmod-driver-container-" + hash64}).String(),
 		}
 
 		pod, err := GetPodForNode(cs, &node, "simple-kmod", listOptions)
@@ -127,6 +153,9 @@ var _ = ginkgo.Describe("[basic][simple-kmod] create and deploy simple-kmod", fu
 			return true, nil
 
 		})
+		if err != nil {
+			explain = err.Error()
+		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), explain)
 
 	})

--- a/test/e2e/basic/util.go
+++ b/test/e2e/basic/util.go
@@ -16,8 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/onsi/ginkgo"
-	"github.com/openshift-psap/special-resource-operator/test/framework"
 	"github.com/openshift-psap/special-resource-operator/pkg/osversion"
+	"github.com/openshift-psap/special-resource-operator/test/framework"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -64,7 +64,6 @@ func GetVersionTriplet(cs *framework.ClientSet) (string, string, string, error) 
 
 	return nodeKernelFullVersion, "rhel" + nodeOSVersion, nodeOCPVersion, nil
 }
-
 
 // GetNodesByRole returns a list of nodes that match a given role.
 func GetNodesByRole(cs *framework.ClientSet, role string) ([]corev1.Node, error) {

--- a/test/e2e/basic/util.go
+++ b/test/e2e/basic/util.go
@@ -5,7 +5,11 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
+
+	errs "github.com/pkg/errors"
+
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +23,86 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	//srov1beta1 "github.com/openshift-psap/special-resource-operator/api/v1beta1"
 )
+
+// Return kernel full version, os version, openshift version
+//                    feature.node.kubernetes.io/kernel-version.full=4.18.0-240.10.1.el8_3.x86_64
+//                    feature.node.kubernetes.io/system-os_release.RHEL_VERSION=8.3
+//                    feature.node.kubernetes.io/system-os_release.VERSION_ID=4.7
+func GetVersionTriplet(cs *framework.ClientSet) (string, string, string, error) {
+	nodes, err := GetNodesByRole(cs, "worker")
+	if err != nil {
+		return "", "", "", err
+	}
+	node := nodes[0]
+	labels := node.GetLabels()
+
+	// Assuming all nodes are running the same OS...
+	os := "feature.node.kubernetes.io/system-os_release"
+	nodeOSrel := labels[os+".ID"]
+	nodeKernelFullVersion := labels["feature.node.kubernetes.io/kernel-version.full"]
+	nodeOSVersion := labels[os+".RHEL_VERSION"]
+	nodeOCPVersion := labels[os+".VERSION_ID"]
+	if len(nodeKernelFullVersion) == 0 || len(nodeOSVersion) == 0 {
+		return "", "", "", errs.New("Cannot extract feature.node.kubernetes.io/system-os_release.*, is NFD running? Check node labels")
+	}
+
+	if nodeOSVersion == "" {
+		// Old NFD version without OSVersion -- try to render it
+		os := "feature.node.kubernetes.io/system-os_release"
+		nodeOSmaj := labels[os+".VERSION_ID.major"]
+		nodeOSmin := labels[os+".VERSION_ID.minor"]
+
+		_, _, nodeOSVersion, err = renderOperatingSystem(nodeOSrel, nodeOSmaj, nodeOSmin)
+		if err != nil {
+			return "", "", "", errs.New("Could not determine operating system version")
+		}
+	}
+
+	if nodeOSrel != "rhcos" {
+		return nodeKernelFullVersion, nodeOSrel + nodeOSVersion, nodeOCPVersion, errs.New("Unexpected error, node not running rhcos")
+	}
+
+	return nodeKernelFullVersion, "rhel" + nodeOSVersion, nodeOCPVersion, nil
+}
+
+// Returns for example rhel8, rhel8.3, 8.3
+func renderOperatingSystem(rel string, maj string, min string) (string, string, string, error) {
+
+	// rhcos version is the openshift version running need to translate
+	// into rhel major minor version
+	if strings.Compare(rel, "rhcos") == 0 {
+		rel := "rhel"
+
+		num, _ := strconv.Atoi(min)
+
+		if strings.Compare(maj, "4") == 0 && num < 4 {
+			maj := "8"
+			return rel + maj, rel + maj + ".0", maj + ".0", nil
+		}
+
+		if strings.Compare(maj, "4") == 0 && strings.Compare(min, "4") == 0 {
+			maj := "8"
+			return rel + maj, rel + maj + ".1", maj + ".1", nil
+		}
+
+		if strings.Compare(maj, "4") == 0 && num < 7 {
+			maj := "8"
+			return rel + maj, rel + maj + ".2", maj + ".2", nil
+		}
+
+		maj := "8"
+		return rel + maj, rel + maj + ".3", maj + ".3", nil
+	}
+
+	// A Fedora system has no min yet, so if min is empty
+	// return fedora31 and not fedora31.
+	if min == "" {
+		return rel + maj, rel + maj, maj, nil
+	}
+
+	return rel + maj, rel + maj + "." + min, maj + "." + min, nil
+
+}
 
 // GetNodesByRole returns a list of nodes that match a given role.
 func GetNodesByRole(cs *framework.ClientSet, role string) ([]corev1.Node, error) {


### PR DESCRIPTION
This PR addresses several bugs:
-  Currently `make deploy` hangs when deleting driver-container-base and simple-kmod simultaneously for example in the GitHub Actions CI, because the reconciliation loop recreates the driver-container-base as a dependency of simple-kmod after deleting it. This results in `make deploy` hanging on namespace deletion because the new driver-container-base finalizer is not handled and deleted. This PR simply changes when in the reconciliation loop we check and reconcile finalizers to be before handling dependencies. That way we are not creating a SpecialResources dependency if the parent is already marked to be deleted.
- It also fixes a bug introduced in the last merged PR where the cluster operator status is never updated correctly
- It also adds a new e2e test to check that NFD is running and get the kernel, OS, and OCP version
- Fixes e2e tests in accordance with changes to object naming scheme with hash from kernel + os version.
- Rewrite renderOperatingSystem and move into a separate package, add RHEL8.3 as a version for RHCOS >= 4.7.