### PR TITLE
Fixing actions/checkouts that should be using the PR code

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,6 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
     - uses: actions/setup-go@v2
     - uses: benjlevesque/short-sha@v1.2
@@ -39,6 +40,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
     - uses: actions/setup-go@v2
     - uses: benjlevesque/short-sha@v1.2

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -15,6 +15,8 @@ jobs:
         (github.event.pull_request.head.repo.full_name == 'openshift-psap/special-resource-operator')
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v2
     - run: make lint
 

--- a/.github/workflows/kube-lint.yaml
+++ b/.github/workflows/kube-lint.yaml
@@ -15,6 +15,8 @@ jobs:
         (github.event.pull_request.head.repo.full_name == 'openshift-psap/special-resource-operator')
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v2
     - run: make kube-lint
 

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -15,6 +15,8 @@ jobs:
         (github.event.pull_request.head.repo.full_name == 'openshift-psap/special-resource-operator')
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v2
     - run: make unit
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -15,6 +15,8 @@ jobs:
         (github.event.pull_request.head.repo.full_name == 'openshift-psap/special-resource-operator')
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v2
     - run: make verify
 


### PR DESCRIPTION
The current github actions which use actions/checkout to test PR code were actually checking out from master, because pull_request_target actions are running in the base of the PR. This caused us to miss a few bugs. This PR should fix that going forward.

I did some testing to verify this. Without specifying a ref in the actions/checkout, it will checkout from the "context" where the action is executed which is the base of the PR for pull_request_target , and it is the merge commit for on pull_request.

This PR will make this explicit by setting the ref in all of the tests which should be using the PR code.