### PR TITLE
Add preStop hook to unload kmods loaded by KVC

### DIFF
--- a/config/recipes/lustre-client/manifests/1000-driver-container.yaml
+++ b/config/recipes/lustre-client/manifests/1000-driver-container.yaml
@@ -116,7 +116,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "kmods-via-containers unload lustre-client $(uname -r)"]
+              command: ["/bin/sh", "-c", "systemctl stop kmods-via-containers@lustre-client"]
         securityContext:
           privileged: true
           hostNetwork: true

--- a/config/recipes/lustre-client/manifests/1000-driver-container.yaml
+++ b/config/recipes/lustre-client/manifests/1000-driver-container.yaml
@@ -113,6 +113,10 @@ spec:
         imagePullPolicy: Always
         name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}-{{.OperatingSystemMajor}}
         command: ["/sbin/init"]
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "kmods-via-containers unload lustre-client $(uname -r)"]
         securityContext:
           privileged: true
           hostNetwork: true

--- a/config/recipes/simple-kmod/manifests/1000-driver-container.yaml
+++ b/config/recipes/simple-kmod/manifests/1000-driver-container.yaml
@@ -62,6 +62,10 @@ spec:
         name: {{.SpecialResource.Name}}-{{.GroupName.DriverContainer}}
         imagePullPolicy: Always
         command: ["/sbin/init"]
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "kmods-via-containers unload simple-kmod $(uname -r)"]
         securityContext:
           privileged: true
       nodeSelector:

--- a/config/recipes/simple-kmod/manifests/1000-driver-container.yaml
+++ b/config/recipes/simple-kmod/manifests/1000-driver-container.yaml
@@ -65,7 +65,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "kmods-via-containers unload simple-kmod $(uname -r)"]
+              command: ["/bin/sh", "-c", "systemctl stop kmods-via-containers@simple-kmod"]
         securityContext:
           privileged: true
       nodeSelector:

--- a/config/recipes/simple-kmod/manifests/kustomization.yaml
+++ b/config/recipes/simple-kmod/manifests/kustomization.yaml
@@ -8,6 +8,6 @@ generatorOptions:
 
 configMapGenerator:
 - files:
-  - 0000-buildconfig..yaml
+  - 0000-buildconfig.yaml
   - 1000-driver-container.yaml
   name: simple-kmod

--- a/test/e2e/basic/simple-kmod.go
+++ b/test/e2e/basic/simple-kmod.go
@@ -142,6 +142,14 @@ var _ = ginkgo.Describe("[basic][simple-kmod] create and deploy simple-kmod", fu
 		}
 		gomega.Expect(err).NotTo(gomega.HaveOccurred(), explain)
 
+		//run command in pod
+		ginkgo.By("Ensuring that the simple-kmod is unloaded")
+		// || true at the end of grep command because we don't want grep to exit with an error code if no matches are found.
+		unloadCmd := []string{"/bin/sh", "-c", "/host/usr/sbin/lsmod | grep -c simple-kmod || true"}
+		unloadValExp := "0"
+		_, err = WaitForCmdOutputInDebugPod(pollInterval, waitDuration, workerNode.Name, &unloadValExp, true, unloadCmd...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		ginkgo.By("Creating simple-kmod again")
 		framework.CreateFromYAML(simpleKmodCrYAML, cl)
 


### PR DESCRIPTION
Currently the deletion of a driver container pod does not unload the kernel modules from the node. One way to fix this is using preStop hooks which execute for example 

`kmods-via-containers unload simple-kmod $(uname -r)`

This is tested and seems to work but I am open to different solutions