### PR TITLE
Fix a requeue bug in reconciliation loop and expand simple-kmod e2e test

### DIFF
--- a/controllers/specialresource_controller.go
+++ b/controllers/specialresource_controller.go
@@ -75,11 +75,12 @@ func (r *SpecialResourceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 		return res, errs.Wrap(err, "Cannot update special resource status")
 	}
 	//Reconcile all specialresources
-	if res, err = SpecialResourcesReconcile(r, req); err == nil {
+	if res, err = SpecialResourcesReconcile(r, req); err == nil && res.Requeue != true {
 		conds = conditions.AvailableNotProgressingNotDegraded()
 	} else {
 		return res, err
 	}
+
 	// Only if we're successfull we're going to update the status to
 	// Available otherwise retunr the recondile error
 	if res, err = SpecialResourcesStatus(r, req, conds); err != nil {

--- a/controllers/specialresource_controller.go
+++ b/controllers/specialresource_controller.go
@@ -75,7 +75,7 @@ func (r *SpecialResourceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 		return res, errs.Wrap(err, "Cannot update special resource status")
 	}
 	//Reconcile all specialresources
-	if res, err = SpecialResourcesReconcile(r, req); err == nil && res.Requeue != true {
+	if res, err = SpecialResourcesReconcile(r, req); err == nil && !res.Requeue {
 		conds = conditions.AvailableNotProgressingNotDegraded()
 	} else {
 		return res, err

--- a/test/e2e/basic/util.go
+++ b/test/e2e/basic/util.go
@@ -175,7 +175,7 @@ func WaitForDaemonsetReady(cs *framework.ClientSet, interval, duration time.Dura
 			return false, nil
 		}
 
-		if ds.Status.DesiredNumberScheduled == ds.Status.NumberReady {
+		if ds.Status.DesiredNumberScheduled == ds.Status.NumberAvailable {
 			return true, nil
 		}
 

--- a/test/e2e/basic/util.go
+++ b/test/e2e/basic/util.go
@@ -164,6 +164,27 @@ func ExecCmdInPod(pod *corev1.Pod, cmd ...string) (string, error) {
 	return stdout.String(), nil
 }
 
+// WaitForDaemonsetReady waits for a duration, checking every interval,
+// for the desired number of DaemonSet pods to equal the number of Daemonset pods
+// that are ready for a given daemonset in a given namespace.
+func WaitForDaemonsetReady(cs *framework.ClientSet, interval, duration time.Duration, namespace string, name string) error {
+	err := wait.PollImmediate(interval, duration, func() (bool, error) {
+		ds, err := cs.DaemonSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			_, _ = Logf("Waiting for DaemonSet %s creation: %v", name, err)
+			return false, nil
+		}
+
+		if ds.Status.DesiredNumberScheduled == ds.Status.NumberReady {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	return err
+}
+
 // waitForCmdOutputInPod runs command with arguments 'cmd' in Pod 'pod' at
 // an interval 'interval' and retries for at most the duration 'duration'.
 // If 'valExp' is not nil, it also expects standard output of the command with


### PR DESCRIPTION
This PR addresses a bug where SpecialResourcesReconcile was returning without error but with a needed requeue to reconcile again, for instance after a time-out waiting for the creation/completion of some hardware state like a driver container build. 

For some reason which is still somewhat of a mystery to me,  this bug was regularly happening on the second creation of simple-kmod but not the first. Because of this I added a second deployment of the simple-kmod special resource to the simple-kmod e2e test, and did some refactoring to that test.