### PR TITLE
e2e-test fixes: namespace the oc debug and clarify logs when no operator deployment found

### DIFF
--- a/test/e2e/basic/available.go
+++ b/test/e2e/basic/available.go
@@ -30,6 +30,16 @@ var _ = ginkgo.Describe("[basic][available] Special Resource Operator availabili
 	ginkgo.It("Operator pod is running", func() {
 		ginkgo.By("Wait for deployment/special-resource-controller-manager to have 1 ready replica")
 		err := wait.PollImmediate(pollInterval, waitDuration, func() (bool, error) {
+			deployments, err := cs.Deployments("openshift-special-resource-operator").List(context.TODO(), metav1.ListOptions{})
+			if err != nil {
+				return false, fmt.Errorf("Error getting list of deployments, %v", err)
+			}
+
+			if len(deployments.Items) < 1 {
+				_, _ = Logf("Waiting for 1 deployment in openshift-special-resource-operator namespace, currently: %d", len(deployments.Items))
+				return false, nil
+			}
+
 			operatorDeployment, err := cs.Deployments("openshift-special-resource-operator").Get(context.TODO(), "special-resource-controller-manager", metav1.GetOptions{})
 			if err != nil {
 				return false, fmt.Errorf("Couldn't get operator deployment %v", err)

--- a/test/e2e/basic/util.go
+++ b/test/e2e/basic/util.go
@@ -233,7 +233,7 @@ func WaitForCmdOutputInDebugPod(interval, duration time.Duration, nodename strin
 	)
 	err = wait.PollImmediate(interval, duration, func() (bool, error) {
 		// Run oc debug  node/nodename -- cmd...
-		ocArgs := []string{"debug", "node/" + nodename, "--"}
+		ocArgs := []string{"debug", "-n", "openshift-special-resource-operator", "node/" + nodename, "--"}
 		ocArgs = append(ocArgs, cmd...)
 
 		stdout, stderr, err := execCommand(false, "oc", ocArgs...)


### PR DESCRIPTION
These two small fixes are needed for the SRO e2e tests to work in the ci-artifacts environment.