### PR TITLE
Fixing Makefile for make bundle, adding bundle for ART

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,18 @@ test-e2e:
 
 # Current Operator version
 VERSION ?= 0.0.1
+
+CHANNELS="4.9"
+
 # Default bundle image tag
-BUNDLE_IMG ?= sro-bundle:$(VERSION)
+BUNDLE_IMG ?= quay.io/openshift-psap/special-resource-operator-bundle:$(VERSION)
 # Options for 'bundle-build'
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif
+
+DEFAULT_CHANNEL="4.9"
+
 ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
@@ -137,9 +143,9 @@ local-image-push:
 # Generate bundle manifests-gen and metadata, then validate generated files.
 .PHONY: bundle
 bundle: manifests-gen
-	operator-sdk generate kustomize manifests-gen -q
+	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE)
-	$(KUSTOMIZE) build config/manifests-gen | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --verbose --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 
 # Build the bundle image.

--- a/bundle/4.9/bundle.Dockerfile
+++ b/bundle/4.9/bundle.Dockerfile
@@ -1,0 +1,16 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=special-resource-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=4.9
+LABEL operators.operatorframework.io.bundle.channel.default.v1=4.9
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.2.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v2
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/bundle/4.9/manifests/image-references
+++ b/bundle/4.9/manifests/image-references
@@ -1,0 +1,12 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: special-resource-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-special-resource-operator:4.9
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: registry.redhat.io/openshift4/ose-kube-rbac-proxy

--- a/bundle/4.9/manifests/special-resource-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/4.9/manifests/special-resource-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: special-resource-controller-manager-metrics-monitor
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: special-resource-controller-manager-metrics-service.openshift-special-resource-operator.svc
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/bundle/4.9/manifests/special-resource-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/4.9/manifests/special-resource-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: special-resource-operator-tls
+  creationTimestamp: null
+  labels:
+    control-plane: controller-manager
+  name: special-resource-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/4.9/manifests/special-resource-dependencies_v1_configmap.yaml
+++ b/bundle/4.9/manifests/special-resource-dependencies_v1_configmap.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+data: null
+kind: ConfigMap
+metadata:
+  name: special-resource-dependencies

--- a/bundle/4.9/manifests/special-resource-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/4.9/manifests/special-resource-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: special-resource-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle/4.9/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml
+++ b/bundle/4.9/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml
@@ -79,6 +79,78 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - acme.cert-manager.io
+          resources:
+          - challenges
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - acme.cert-manager.io
+          resources:
+          - challenges/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - acme.cert-manager.io
+          resources:
+          - challenges/status
+          verbs:
+          - update
+        - apiGroups:
+          - acme.cert-manager.io
+          resources:
+          - orders
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - acme.cert-manager.io
+          resources:
+          - orders/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - acme.cert-manager.io
+          resources:
+          - orders/status
+          verbs:
+          - update
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - apiextensions.k8s.io
           resources:
           - customresourcedefinitions
@@ -88,6 +160,15 @@ spec:
           - get
           - list
           - patch
+          - update
+          - watch
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          verbs:
+          - get
+          - list
           - update
           - watch
         - apiGroups:
@@ -147,6 +228,15 @@ spec:
           - update
           - watch
         - apiGroups:
+          - auditregistration.k8s.io
+          resources:
+          - auditsinks
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - build.openshift.io
           resources:
           - buildconfigs
@@ -173,10 +263,11 @@ spec:
         - apiGroups:
           - cert-manager.io
           resources:
-          - certificates
+          - certificaterequests
           verbs:
           - create
           - delete
+          - deletecollection
           - get
           - list
           - patch
@@ -185,15 +276,122 @@ spec:
         - apiGroups:
           - cert-manager.io
           resources:
-          - issuers
+          - certificaterequests/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificaterequests/status
+          verbs:
+          - update
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
           verbs:
           - create
           - delete
+          - deletecollection
           - get
           - list
           - patch
           - update
           - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates/status
+          verbs:
+          - update
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - clusterissuers
+          verbs:
+          - deletecollection
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - clusterissuers/status
+          verbs:
+          - update
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - issuers
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - issuers/status
+          verbs:
+          - update
+        - apiGroups:
+          - cert-manager.io
+          resourceNames:
+          - clusterissuers.cert-manager.io/*
+          resources:
+          - signers
+          verbs:
+          - approve
+        - apiGroups:
+          - cert-manager.io
+          resourceNames:
+          - issuers.cert-manager.io/*
+          resources:
+          - signers
+          verbs:
+          - approve
+        - apiGroups:
+          - certificates.k8s.io
+          resources:
+          - certificatesigningrequests
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - certificates.k8s.io
+          resources:
+          - certificatesigningrequests/status
+          verbs:
+          - update
+        - apiGroups:
+          - certificates.k8s.io
+          resourceNames:
+          - clusterissuers.cert-manager.io/*
+          resources:
+          - signers
+          verbs:
+          - sign
+        - apiGroups:
+          - certificates.k8s.io
+          resourceNames:
+          - issuers.cert-manager.io/*
+          resources:
+          - signers
+          verbs:
+          - sign
         - apiGroups:
           - config.openshift.io
           resources:
@@ -242,6 +440,38 @@ spec:
           - list
           - update
           - watch
+        - apiGroups:
+          - coordination.k8s.io
+          resourceNames:
+          - cert-manager-cainjector-election-core
+          resources:
+          - leases
+          verbs:
+          - patch
+        - apiGroups:
+          - coordination.k8s.io
+          resourceNames:
+          - cert-manager-cainjector-leader-election
+          resources:
+          - leases
+          verbs:
+          - patch
+        - apiGroups:
+          - coordination.k8s.io
+          resourceNames:
+          - cert-manager-cainjector-leader-election-core
+          resources:
+          - leases
+          verbs:
+          - patch
+        - apiGroups:
+          - coordination.k8s.io
+          resourceNames:
+          - cert-manager-controller
+          resources:
+          - leases
+          verbs:
+          - patch
         - apiGroups:
           - ""
           resources:
@@ -475,6 +705,59 @@ spec:
           - update
           - watch
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - operator.cert-manager.io
+          resources:
+          - certmanagers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - operatorgroups
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
@@ -534,6 +817,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
         - apiGroups:
           - security.openshift.io
           resources:

--- a/bundle/4.9/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml
+++ b/bundle/4.9/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml
@@ -1,0 +1,885 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "sro.openshift.io/v1beta1",
+          "kind": "SpecialResource",
+          "metadata": {
+            "name": "simple-kmod"
+          },
+          "spec": {
+            "configuration": [
+              {
+                "name": "KMOD_NAMES",
+                "value": [
+                  "simple-kmod",
+                  "simple-procfs-kmod"
+                ]
+              }
+            ],
+            "dependsOn": [
+              {
+                "imageReference": "true",
+                "name": "driver-container-base"
+              }
+            ],
+            "driverContainer": {
+              "buildArgs": [
+                {
+                  "name": "KVER",
+                  "value": "{{.Values.kernelFullVersion}}"
+                },
+                {
+                  "name": "KMODVER",
+                  "value": "SRO"
+                }
+              ],
+              "source": {
+                "git": {
+                  "ref": "master",
+                  "uri": "https://github.com/openshift-psap/kvc-simple-kmod.git"
+                }
+              }
+            },
+            "namespace": "simple-kmod"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    description: The special resource operator is an orchestrator for resources in a cluster required to deploy special hardware and software. Examples include hardware accelerators or software defined storage, where extra management or kernel modules are needed.
+    operators.operatorframework.io/builder: operator-sdk-v1.2.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+  name: special-resource-operator.v4.9.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: SpecialResource is the Schema for the specialresources API
+      displayName: Special Resource
+      kind: SpecialResource
+      name: specialresources.sro.openshift.io
+      version: v1beta1
+    required:
+    - description: Discovers special resources and labels the nodes with the PCI vendor ID.
+      displayName: Node Feature Discovery
+      kind: NodeFeatureDiscovery
+      name: nodefeaturediscoveries.nfd.openshift.io
+      version: v1
+  description: "## About the managed application \nThe SRO will deploy the complete stack for enabling the accelerator in a cluster. \nIt manages the drivers, device-plugin, node-exporter, grafana and feature discovery.\n## About this Operator\n README: [https://github.com/openshift-psap/special-resource-operator](https://github.com/openshift-psap/special-resource-operator)\n\n## Prerequisites for enabling this Operator\nThe SRO has a dependency on NFD (Node Feature Discovery)\n"
+  displayName: Special Resource Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAYAAAAEiCAYAAADwEwVaAAAACXBIWXMAABYlAAAWJQFJUiTwAAAck0lEQVR4nO3dfYwdV33G8WeCCbaJsr7WKo4a/AalEJXIm0JBFQE7ElQICDGoav8hsqNKFbQ0MRIqElIbG6RKICTstFLVSig2RqXtH7BJGoQaUHZDKgSNyLou6gsq2XVqFKOtrzei2WAST3X2nvGO79x7986dt3PmfD+SRbKzODuzu+eZ33mN4jgWACA8m/ieI0TdKDos6aCkA5KmBjyCM5IuSZqTtGD+dOJ4MfNZgMeoABCUbhQdkWT+7J7gvpdsGJhQmOvE8ULmMwCPEAAIQjeKZiSdlLSvxPtdSsJA0mwnji9lPgNwGAEQsG4UbZM00/cELrXtzdZ29xwf0tVTpjM2ZKgO4AUCICDdKEr6vE2jv3+DO093d8z62v/djSLT8N+fuVA98/xmTSAQBnAVAdBy9i0/6fcu8gacvN16EwbdKDJf76HMhfoRBnASAdBSJTb8gzxsulQ6cTw34Frj7L3PjlHlNIEwgDMIgBayA56zE850ycM0Zkc7cXzSladoG/+5kgd7q0IYoFEEQMvYAc+Har4rJ4LAs8a/n3ddbPAfAdAi3Sg6KumBBu+osSCoseqpw3wqDJhaisoQAC3R4GyXQZZsA3a8jgbMzm46WcM0z7qtpLqInBxvgd8IgBZoqNtnHCt2/v3Jqro1HAu+KiWhWtmzRHgIAM91o8jM63/Cg7s4VeabrL3vky3p8snrYds95MzgO/xEAHjMDnouetb1UWjmi+3uOeLoFM+6raS62qgKkBsB4LFuFM153hCupFYbL9jdNxeScYPUVhV77Armgy3s5y/LvA1VqgKMjQDwlN3V8kuhPwdkUBVgbASAhzzt+kH9HrZVwSzPHoMQAB5yaI8b+GEpNRuLdQW4igDwTDeKTH/4s6E/B0wkWVdwlO4hGNdlPgLXMciHSU3ZyvFZM4HAzqhCwKgAPOLRnH/4Y237DradCBMVgF8Oh/4AULrddhX5otlLyk4wQCCoADxB3z9qdIpxgjBQAfjjaOgPALVJxglO2l1W0VJUAB5g3j8aNm8rAnYkbRkqAD+wBQKaZLYbecLOHDrAd6I9qAA80I2iBU9PuUI7URG0BAHgONsH+0zozwFOIgg8RxeQ+5j6CVclXUMn7Sw1eIYKwHHdKFoM9NAT+Ifpo56hAnCYXapP4w9fmOmjCywo8wcB4Db2aoFvzGy1B2wQ0H3pOLqAHNaNoktM/4TnzEDxkUmO/0T1qAAcZbt/aPzhOzNQ/AzdQm4iANxF+Yw2SbqFWEjmELqAHGTflLqhPwe01rFOHLO3lQOoANzE4C/a7AGzup21A80jANxEAKDt9tEl1Dy6gBzDvv8I0L2dOOao0wZQAbiHt3+E5iGznQTf9foRAO5h9g9CdIgQqB9dQA6h+wfQqU4c8xJUEyoAt/CDj9AdYguJ+lABOISdP4Gr7uScgeoRAI7g4BfgGiuS9nTi+BKPpTp0AbmDshdYZ/bBOs7zqBYVgCPo/gEGoiuoQlQADuDgF2Ao9gyqEAHgBhZ/AYPtZ7uI6tAF5AAOfgFGmu/EMSFQASqAhnHwC7Ch/ewcWg0CoHnM/gE2doRnVD66gBrEwS/A2JY6cUwVUDIqgGYx+AuMZ7ddLIkSEQDNIgCA8fH7UjK6gBrCzp9Abmc6cUwVUCIqgObwNgPks8+Om6EkBEBzmP0D5Md6gBIRAA2w3T/7grtxoDgCoEQEQDPo/gEmQwCUiEHgBrDzJzC5ThxHPL5yUAHUzM5lpvEHJsTmcOUhAOrH4C9QDAFQEgKgfvT/A8UQACUhAGpE9w9QChaDlYQAqBc7GgLFTbEvUDkIgHrR/QOUg26gEhAANeHgF6BUVAAlIADqw9s/UB4qgBKwEKwmnPsLlG5vJ44XeayTowKoQTeKDtP4A6WjG6ggAqAedP8A5aMbqCC6gCrGub9AZTggpiAqgOrx9g9Ugy3VCyIAqkcAABVhY7hiCIAK2e6fu1t7g0DzCIACCIBq8fYPVIsAKIAAqBZbPwPVYhC4AAKgIvbc3/2tvDnAHWwMVwABUB26f4B60A00IQKgOnT/APWgApgQAVAB2/3DHGWgHlQAEyIAqkH3D1Cf3falCzkRABX4qfSx1t0U4Da6gSZAAJQsiqKZX5He1KqbAtxHN9AECIDyce4vUD8qgAmwG2iJot7WD4sX2fsfqF0njiOeej5UAOXi3F+gIWwMlx8BUC66f4DmEAA5EQAliXrL0dfm/v9YOt+GewI8wzhATgRAea6+/X9N2tqC+wF8QwWQE4PAJYj6jn3cJWnB5xsC/HV7J4759RsTFUA5rtn355ykb0oXPL4fwFd0A+VAAJQjM/j7GWmHp/cC+IxuoBwIgIKi3tSz3f1/C1UA0AgCIAcCoLih2z7/kbTjF9JLmQsAqrLbnsWNMRAABdjB30PD/oYVSX8gXclcAFAlqoAxEQDFDH37TzwqbX1KWs5cAFAVAmBMBEAxmcHfQe6Rpi/1CgIA1WMm0JhYBzAhO/j7xLj/79skzWc+CqAKbAw3HiqAyeU68/espPul1cwFAKVjY7jxbPLhi6yLPVYufbRc+odoW1Jarkqbd0nvOJfz6zotbXmPdPEuaXvmIoAymd/dOZ7oaEEEgJ0WlvQLJo36jG3Ut+U9wP0X0krexj9xSNr+iLR8hzSduQigLIwDjKFVAWDLvuQtPmng92c+saAHC07tNIPCT0oXd1IJAFWhC2gMXg4C266aGfsnafQzq3GrMmNX+hZhTo0hBIBKsTHcBryoAOyb/YFUg9/YqVvPSxfOlbDPj5kT+m5p+zPSyjZOEQOqMMPGvKM5GQDd3uEqB21jX3oXThFz0stl/V0mBO6Wph6XVq+XtmQ+AUARpv04yRMczpkA6EbRQdvoO32u7mPSLZkPFmCmh75X2kIIAKVjHGADjY4B+NLop+1VNUt6d/W2jWBMAChXpxPHl3img9W+EMwM4Haj6Hg3isw35Rt2MzUvGv8XpG5V+zmcs2MCz0kXMxcBTIoqYITaAqAbRYe7UWQWZjzbWxTr38DnBenFzAdLtEIIAGUjAEaoPABsw78o6SHXBnTzeqLEAeBhkhBgB1GgFCwIG6GyAOhr+Gubo98GJgQ+JE0/SiUAFOX1S2fVSg8AM7Db1ob/R9JNmQ9WyGwb8WecKAYUwsZww5UWAHZwd84O7Lbyjf/ZBqZp/qW02ewi+suKxx+AFiMAhiglALpRdMSuuKPcqoDdRXQrh8oAE2EcYIhCAWB22bRv/V/ycVaPT8yCsdulKWYIAblRAQwxcQDY7RoWeeuvz0pv3+rtX2WGEJDHlN1AEn0mCgAzw0fSM6G99b9vbSlA8+6TphkXAHKhChggdwB0o+ioneETnE0OzchJxgXOUw0A4yAABsgVAN0oMjvrPZC5EIg7Hds91YwL3MF6AWAcDAQPMPZmcGb/HruFQ7AuS6s3O7pj5z3S6hel+NXS1sxFAGJjuKyxKgDb5x9042+Y7Zp3ZT7qBtMl9JvSVmYJAUPRDdRnwwCwq+iC7PMfZL+0OuDDTjhnZwmdYL0AMAjdQH1GBoCdOjWbuRCwezwYdD0mTZm5uSwcA9b9b+/cEaSMHAOwi7yY59+nqkNhymbm6H5OWv6oNO3BlwtUrhPHEU953dAKwG7vQOM/wIcc7gZKW7FrBj5ENQCseWsUfZAnsW5gANiun6OZC1jzJ9L/+fQknrLbSDA2gNDdJv1O6M8gbWAA2MafvX2GuEWavmPwJWetpMYGWDyGUP2MgeBrZALAvv0fynwmrvHH0nM+PpGzvbegaXPOAFtJIDQvSr/KN31dJgDo+hnPe6Wdrq4JGIc5Z8CsG+DoSYTkFem1UW8jy+CpPwB4+8/nzx3ZHG5S5+zRkwwSIzAsCLP6K4DDmc/AUO+Xdvg2FjCIGSR+vR0kplsIASAALAKgoM97XgWkmUFi0y30zRbdEzAAAWBdDQB7wEsrz/Kt0q3Sjns8WRcwDtMt9FFph+kW+neCAC1zrnc7UxEHxKxJVwC8/U/oC1LUtjmzplvondKOQ9KLjA+gLc6t30fwVYD6AoAHMqHXSJtPt3Q2zaPSVjM+YKaNXm5RpYPwvCB1UzcdfHunJADM4e69jSQxKXMwy10tHkA100bfJG0xA8UEAXz0X9LPU1928AGgVAXAvNgS/I10XZuXTyeriQkC+OgHa0d6XLWbcYD1ACANS2C6gh4NYGFVOgiYMQRf/L20o+9LDf7FNwmA4JOwLG+Rph8IZNB0xc4YMr9FJgioCOAq87N5Nvu1Bf/iSwBU4H5pqs3jAf2SqaN0DcFV314bA84IPgDWDoTpRtEiawDKZRrB90pbBrx1tJ4ZBzkirXxcuv56Rw/RR1j2240QB+jEAR8Un1QANP4lMw3f30rLIe6pnR4juF9aZR0BmmQWNA5p/PVT6T+6URTsGqhBu4GiJObcgCeli6EerGBa/dPSFrOOwAQBK4vRhE9nB3+vsq/+D3Wj6FI3io7aKfHBIAAqtlPa/qB0sdU3OQYTBO+0W0w87ulZCvCPeel4asRXfXatt3aNeU97QNKiDYIgxkUJgBrcJW0/RQisMb+MvyftNDOHGDBG1T424u3f+J50Q9+HkiB4thtFJ9seBARATQiBa52z4wQ323ECuodQNvOCMazvP/EdqZP54LpDNgha2zWUzAKKM1dQCbOnjtlWgaebZU5Y+5S0/LvSa5k9hCKeky7uk7aP81eM+VZmhrSOmz+dFs0aIgAaYN54T9PAjWS22P6Y9MKtG5TwQL9fSC+9Wdo87tSzp6Wl148/E9L8tUc6cXwyc8VDdAE14IS05RPSS8HdeA7JoHEyVtC3kyMwkBlT+u0cjb96ewRtynxwuCk7a2ihG0XeLySjAmjQo9LFQ2OWqZBu603pu/Ae6Ua6iNBv0sWXpto8MfnP08O2IljMXPFAUgHM89NUPwaG8zlrt5wwA8f32OmkzCKCCq68Xyj2MnG3+SvMQHHmigeSCmDOrpZGA6gEivmApD+Unn+rNEVlEB4z4Gteps4VuPOS3sLO2GpgLnPFUUkF4M0X3Ebmh/dMwCuGi3qsFwI3UxmEx7w8vbtg42/8RFrKfDA/c6jWE90oOu7LtNEkALzsv2oTs2LYbBuxK/QHUdBjdqFZEgZ/J51nALl9zEwfc161qZzL2Gjqv8udEHO/7RZyfpA4uemFzBXUzoTAD6TV23j0pXis1zV0yx6pY/o3Pyt1fyydb8GtBc2cPfHm3uFLW8t6DgNWBBe1O6kGXP5erY0BqHcu8CU7xQkN+6X04qekiLUC1ZjqneFsuo3Ov1/aeuPo1aBwhFktbrZ2qGKLdfPz8Ejmo6UxYwOHO3Hs3It2OgBm7Yg2HPFVafk+aZrvR7V29WZArH5QWn6HdAOB4BbT8JsdPUdt6laUeSl4ttq7dnIBWToAjkj6UuYz0Kh/k5bvkqbZUL8+6UC4Tbr+ZlYjN8J09Xy+ojf+QWqaj33KBoET20mkA2BP9SGISZgDVe6WpkI8XcwFSZfRu6SlO6VNu6XtTDetxnlp+a+lG07nXM1bhpxbQhThTJfQ1QBQLwQW7FQmOIiN5NxhBupnpNXfki6+XXr5ddJNhMJkTKP/ZelVX5c6RadzFlFjAMh2CZkQmM1cqVF/ANAN5LinpOV76BJy0i4bDKZS+A3putfRfTSQmZb7fenn/yhNPyJtceVnueYASBzrxHFjq4j7A4BuIA/QJeSX22w30vukC2+ULr9BuhJSxWAWWZkN174nbZ+XtjT5lj9KQwGgJscFrgkA9UKAbSE8YXbJPMbUXa8l4fA2qXuz9IKpHLZLV7ZKm32rHkxDf1G67ofSle9Ku8/Z/Zt80WAAyI4LHKg7BAYFgDkh/6HMZ8JJZpbQR6VpV9+qUNxtqQU6SVCYf75R2mTGH9L/gbIri+elCy/arctfkTY9Yf97z0s3Pm2ny1Y5PbNODQeAbAgcrHNn0UwAiEVh3jELxz4nXccAMTA5BwJAdnD4QF0zhIbtf+H08mVc69XS1s9Km5+UltlLCJjM9FpR1Tjz4j3XjaKZOr6QYRUAg8GeohoAJuPYwRy1VAIDKwDbB3UqcwHOoxoA8nNwA8ZaKoGBAWB5ecINet4iTZtXhwd6bxIARphx8/yIykNgaABQBbTD/dLUT6SVO0J/EMAIZt+n4VcbVWkIDBwDSNhTbRaZEdQOZhXxJ5gyCmQsSl3Hd4GtZExgaAWgXhVwiRlB7XGHNP0v0ot0CwHrdvXWVLi+Bbh5CT9Z9lGTIwPAMgFQxnmZcIAZJE66he6SXuR7gtB9xJ8jQ/fZ7qDSQmDDALBVwJHMBXhtmzR1Str6z9IFxgcQsvvKPQ+4avvK7JUZ68btlqXzmQvw3q3Sjkd6p49dYNooQnOHfRny7LYPdaOolFmaIweB0+zisAUGhNvNHEP5p2w3jUCYCvhWf7fs/nDR8wTGDgBxXkAwLkurfyVdPi5NEQRoq4oPgq+D+fWcKbJ5XK4AENtFB4UgQJt5/vafONOJ44nXCEwy+HFYTCMMgtlW2MwY+k9p1Uwdpe8PbWFmwLWg8Tf2daNo4kHh3BWAODMgWFQEaAPzIvOMtOLh4O8od3bieG7E9YEmCgD1QuCkGY3OXEDrJUHwkDTFqmL45kF7iFLLvnHmnWxP3hPFigSAWYwwZ+elIlDflC58RtpBEMAHpuvHrH9p6Tfr4U4cH8x8dISJA0C9EJixIUD3cOCelp77rLSzLccDon3Mls+PS6stP4w/V1dQoQAQ4wHoc15a/oL02tPt/iWDZ6bsZoi3tK/rp99SJ473ZD46ROEl0J04NmMBJzIXECTzC3ZC2vK8nTnE6mI0zTT+T0oXA2j8jd15VgkXrgASrA/AMI9Lz/0F3UNoQNL475S2B/T8x14gVmYAMCiMkS5JKw9KVx6SOkwjRdUCbfwTpzpxfDjz0T6lBYDYLwg5mKrgK9LOx3hoqEDgjX9i70ZVQKkBIGYGIacXpO4j0itf5KQylMTM9vkn6aXXSJsDf6YbVgGlB4B6IWDmon4jcwEYwcwg+rL0KrqIMKl7pNUTzEBLG1kFVBIAYnooCjLrCk5L049IWwgDbMR0N5yWlu8IY6ZPHiOrgMoCQIQASkIYYBSzrfNX2re3T5mGVgGVHoXGGgGU4W3STlPWP9vr233OlPn8pmOqt5//8iN+nupVp2YqgAQbx6EKP5bOf03a+nWpwwByWMwiw49L17d8W4eyrHTieOBB8rUEgAgBVOx56cK3pVf9gzTNgrP2MtXfMekyb/y5DTw+srYAECGAmpjtqv9VWjbjBvPSFqoD/9HwFzZwp9BaA0CEABpg1hp8X/r5V+x2FAwk+8G09EeklXulKzdKndCfRwk6/ecF1B4AIgTQMNNdNCe9/Jh0y1lJVAhuMQu5Pi1deH87jmx0yb12Ys5VjQSAmCIKhyQVwvekG74jdc7yzamd2TX2I1L3Puk6unkqk+kGaiwARAjAYWaG0RPSy9+VdlMlVCNp9H9feiWQrZqblpkN1GgAiBCAJ8zA8pJ00YTCj6SbFqQtVAr5faD35/z7pa306zfimhPDGg8AsYEcPGbGE/5HuvxD6YqpFkylQDD0TNlVuu+Slu6UNr1x7bwgNOxYJ46vHhjjRACIEEDLmHGFZemFH0ibLkqbvmUHNNu6RmGX/fM+6cLbpcu/Jt3AG76T5jtxfCD5wpwJAHGoDALyE2nJ3K0JiBekl5+XbnzaNphnHZ2qmjTyU/atfq903RukK6+Xdmc+Ga66ZhzAqQDQegjMcrwksF5JmH9+RdpkxiDSj+VlafO3SpguuVda/XXpZ6l/X2vczT+/TrqJLRda5ermcM4FQIK1AgBQiasDwZXuBlqE3cP6Xr7/AFCqmeQvczYAtL6d9J2s3geA0lwdA3A6ANQLgTmbWGcyFwEAee1JPt/5AFAvBMyAhZm6dCpzEQCQh18BoF4IXLLjAp/MXAQA5OZNACQ6cXxc0u2MCwBAMd4FgHohsGDLmPnMRQDAWLwMAK13CZlxgWOZiwCADXkbAAm7sRFTRQEgJ+8DQOtTRU2X0MOZiwCAgVoRAFrvEjpoZwlRDQDABloTAAk7S+gAC8cAYLTWBYDsLKFOHJvVwycyFwEgbFdPBGtlACQ6cXzEDhAvZS4CQOBaHQC6di8hqgEAkBaTZ9D6AND6ADHVAACEFgAJqgEAWA8AZ08Eq1o3isxMIXPeAOeZAghGJ46j5F6DqgDSqAYABOia/dOCDQBdOzZwO+sGAARgMX2LQQdAIrVu4BiriAG02EL61giAFLux3Ax7CgFoqbn0bQU7CLyRbhSZfYWOM0gMoCVWOnG8LX0rVABDdOJ41lYDnDcAoA3m+u+BABjBDhKbbqG9nD4GwHOZAKALKAfWDgDw2N5OHDMLaFJm7UAnjvcwWwiAZ5b6G38RAJOx3UImCE75+PUDCM5s5iMEwOTs+MBhu4iM8QEALjs56GtjDKAkjA8AcNQZu9A1gwqgJKnxgXvZchqAQ44P+1KoACrQjSKz2OKI/TPVuhsE4AszWWWP6bIe9PVSAVQgtX6AGUMAmjQ7rPEXFUA9ulFkgsAEwqEQ7heAMzJz/9OoAGpgvgF2xtBepo4CqMmpUY2/qACaQUUAoAYj3/5FBdAMKgIAFdvw7V9UAG6gIgBQsg3f/kUF4AYqAgAlOjFO4y8qADdREQCY0Mh5//2oABzUVxGcYB0BgDEdGbfxFxWAH1hZDGAM8504PpDnQREAHrFBcNB2D7HpHICE6SWYGbfvP0EAeKobRaaLyPzZH/qzAKAP23PMcyEAPGe3oT7MgDEQrFN2zDA3AqAl7MyhIzYMGCcAwnBG0oE8A79pBEDLME4ABGOifv80AqDFbPeQqQruDv1ZAC10pzmIqshtEQABoHsIaJ17O3E88JzfPAiAwNjZQyYM9oX+LABPfbITx0OPecyDAAhUN4pmbBAcpCoAvDHxjJ9BCIDApQaNqQoAt5Xa+IsAQJqtCg4zVgA4p/TGXwQAhrFjBQeZQQQ0rrQ+/34EAEayM4iSLiLWFQD1KmW2zzAEAMZGFxFQG7PI62DRef4bIQAwkW4UHbSVAXsQAeUy2zsc7sTxQtXPlQBAIalZRIwXAMU9bBv/ifb2yYsAQGlSYcA21UB+lQ32DkMAoBKpwePDrC8ARqqty6cfAYDKpcLgIJUBcI1jnTg+2tQjIQBQK8YMgDWNvfWnEQBoTCoMDrAnEQJhpncerbuvfxgCAM6wU0uTMGDRGdrmlFlQWdcMn3EQAHCSXXR2gHEDtMC8bfgb7e4ZhACA82xX0YFUdxHVAXwwb7t7Kl3NWwQBAO+kqoMDDCTDQc43/AkCAN6zZx8n1QFrDtAU08d/0oeGP0EAoFVS3UUHCATUwMzqMbt1Hu/E8aJvD5wAQKsRCKiImcdvpnLOujSrJy8CAEGxgZAeQ2CGEca1ZBp8X9/2ByEAELy+QeUZZhkhZcU2+l717Y+LAAD6pLqNZlL/yyrlcCRv+nOdOJ5t810TAMAY7IZ2M4RCa82nGn3nFmxVhQAAJmRDYU8qEPYwyOwNM4g7F8Jb/igEAFAyuy4hHQ57GFdolOnHX0g1+K3ry58UAQDUxA4270lVC3voSipdurE3/7vQlhk7VSAAAAfYqkG2Ykimqm6jS2koM1C7aBv5xVRj7+2c/CYQAIAHUgGRBEMSEmppF5Ppo79kG/dF+8+mkb8U0iBt1QgAoEVsN9M2e0dJN5OG/LtqCI+kIU9bSH0sadhF414/AgAAQiTp/wGp07dbIvUIVgAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - shipwright-build
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - builds
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - issuers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusteroperators
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusteroperators/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - proxies
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - imagestreams/layers
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/log
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - csi.storage.k8s.io
+          resources:
+          - csidrivers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams/layers
+          verbs:
+          - get
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - use
+          - watch
+        - apiGroups:
+          - shipwright.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - shipwright.io
+          resources:
+          - buildruns
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - shipwright.io
+          resources:
+          - buildstrategies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - shipwright.io
+          resources:
+          - clusterbuildstrategies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotcontents
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotcontents/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshots/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - sro.openshift.io
+          resources:
+          - specialresources
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - sro.openshift.io
+          resources:
+          - specialresources/finalizers
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - sro.openshift.io
+          resources:
+          - specialresources/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - csidrivers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - csinodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - volumeattachments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - tekton.dev
+          resources:
+          - taskruns
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - tekton.dev
+          resources:
+          - tasks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: default
+      deployments:
+      - name: special-resource-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                - --tls-cert-file=/etc/secrets/tls.crt
+                - --tls-private-key-file=/etc/secrets/tls.key
+                - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 250m
+                    memory: 64Mi
+                securityContext:
+                  readOnlyRootFilesystem: true
+                volumeMounts:
+                - mountPath: /etc/secrets
+                  name: special-resource-operator-tls
+              - args:
+                - --metrics-addr=127.0.0.1:8080
+                - --enable-leader-election
+                command:
+                - /manager
+                env:
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: RELEASE_VERSION
+                  value: 0.0.1-snapshot
+                - name: SSL_CERT_DIR
+                  value: /etc/pki/tls/certs
+                image: quay.io/openshift-psap/special-resource-operator:release-4.9
+                imagePullPolicy: Always
+                name: manager
+                resources:
+                  limits:
+                    cpu: 300m
+                    memory: 300Mi
+                  requests:
+                    cpu: 300m
+                    memory: 300Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                volumeMounts:
+                - mountPath: /cache
+                  name: cache-volume
+              securityContext:
+                runAsGroup: 499
+                runAsNonRoot: true
+                runAsUser: 499
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - name: special-resource-operator-tls
+                secret:
+                  secretName: special-resource-operator-tls
+              - emptyDir: {}
+                name: cache-volume
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: default
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - GPI
+  links:
+  - name: README
+    url: https://github.com/openshift-psap/special-resource-operator
+  maintainers:
+  - email: zkaiser@redhat.com
+    name: Zvonko Kaiser
+  - email: dagray@redhat.com
+    name: David Gray
+  maturity: alpha
+  provider:
+    name: Red Hat
+    url: redhat.com
+  version: 4.9.0

--- a/bundle/4.9/manifests/special-resource-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/4.9/manifests/special-resource-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: special-resource-prometheus-k8s
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/4.9/manifests/special-resource-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/4.9/manifests/special-resource-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: special-resource-prometheus-k8s
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: special-resource-prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/bundle/4.9/manifests/sro.openshift.io_specialresources.yaml
+++ b/bundle/4.9/manifests/sro.openshift.io_specialresources.yaml
@@ -72,42 +72,50 @@ spec:
                 type: object
               dependencies:
                 items:
+                  description: SpecialResourceDependency a dependent helm chart
                   properties:
-                    name:
-                      type: string
-                    repository:
+                    chart:
                       properties:
-                        caFile:
-                          type: string
-                        certFile:
-                          type: string
-                        insecure_skip_tls_verify:
-                          default: false
-                          type: boolean
-                        keyFile:
-                          type: string
                         name:
                           type: string
-                        password:
-                          type: string
-                        url:
-                          type: string
-                        username:
+                        repository:
+                          properties:
+                            caFile:
+                              type: string
+                            certFile:
+                              type: string
+                            insecure_skip_tls_verify:
+                              default: false
+                              type: boolean
+                            keyFile:
+                              type: string
+                            name:
+                              type: string
+                            password:
+                              type: string
+                            url:
+                              type: string
+                            username:
+                              type: string
+                          required:
+                          - name
+                          - url
+                          type: object
+                        tags:
+                          items:
+                            type: string
+                          type: array
+                        version:
                           type: string
                       required:
                       - name
-                      - url
+                      - repository
+                      - version
                       type: object
-                    tags:
-                      items:
-                        type: string
-                      type: array
-                    version:
-                      type: string
-                  required:
-                  - name
-                  - repository
-                  - version
+                    set:
+                      type: object
+                      x-kubernetes-embedded-resource: true
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
                 type: array
               driverContainer:

--- a/bundle/4.9/manifests/sro.openshift.io_specialresources.yaml
+++ b/bundle/4.9/manifests/sro.openshift.io_specialresources.yaml
@@ -1,0 +1,229 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: specialresources.sro.openshift.io
+spec:
+  group: sro.openshift.io
+  names:
+    kind: SpecialResource
+    listKind: SpecialResourceList
+    plural: specialresources
+    shortNames:
+    - sr
+    singular: specialresource
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: SpecialResource is the Schema for the specialresources API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SpecialResourceSpec defines the desired state of SpecialResource
+            properties:
+              chart:
+                properties:
+                  name:
+                    type: string
+                  repository:
+                    properties:
+                      caFile:
+                        type: string
+                      certFile:
+                        type: string
+                      insecure_skip_tls_verify:
+                        default: false
+                        type: boolean
+                      keyFile:
+                        type: string
+                      name:
+                        type: string
+                      password:
+                        type: string
+                      url:
+                        type: string
+                      username:
+                        type: string
+                    required:
+                    - name
+                    - url
+                    type: object
+                  tags:
+                    items:
+                      type: string
+                    type: array
+                  version:
+                    type: string
+                required:
+                - name
+                - repository
+                - version
+                type: object
+              dependencies:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    repository:
+                      properties:
+                        caFile:
+                          type: string
+                        certFile:
+                          type: string
+                        insecure_skip_tls_verify:
+                          default: false
+                          type: boolean
+                        keyFile:
+                          type: string
+                        name:
+                          type: string
+                        password:
+                          type: string
+                        url:
+                          type: string
+                        username:
+                          type: string
+                      required:
+                      - name
+                      - url
+                      type: object
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                    version:
+                      type: string
+                  required:
+                  - name
+                  - repository
+                  - version
+                  type: object
+                type: array
+              driverContainer:
+                description: SpecialResourceDriverContainer defines the desired state of SpecialResource
+                properties:
+                  artifacts:
+                    description: SpecialResourceArtifacts defines the observed state of SpecialResource
+                    properties:
+                      claims:
+                        items:
+                          description: SpecialResourceClaims defines the observed state of SpecialResource
+                          properties:
+                            mountPath:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      hostPaths:
+                        items:
+                          description: SpecialResourcePaths defines the observed state of SpecialResource
+                          properties:
+                            destinationDir:
+                              type: string
+                            sourcePath:
+                              type: string
+                          required:
+                          - destinationDir
+                          - sourcePath
+                          type: object
+                        type: array
+                      images:
+                        items:
+                          description: SpecialResourceImages defines the observed state of SpecialResource
+                          properties:
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            path:
+                              items:
+                                description: SpecialResourcePaths defines the observed state of SpecialResource
+                                properties:
+                                  destinationDir:
+                                    type: string
+                                  sourcePath:
+                                    type: string
+                                required:
+                                - destinationDir
+                                - sourcePath
+                                type: object
+                              type: array
+                            pullsecret:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          - namespace
+                          - path
+                          - pullsecret
+                          type: object
+                        type: array
+                    type: object
+                  source:
+                    description: SpecialResourceSource defines the observed state of SpecialResource
+                    properties:
+                      git:
+                        description: SpecialResourceGit defines the observed state of SpecialResource
+                        properties:
+                          ref:
+                            type: string
+                          uri:
+                            type: string
+                        required:
+                        - ref
+                        - uri
+                        type: object
+                    type: object
+                type: object
+              forceUpgrade:
+                type: boolean
+              namespace:
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                type: object
+              set:
+                type: object
+                x-kubernetes-embedded-resource: true
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - chart
+            - namespace
+            type: object
+          status:
+            description: SpecialResourceStatus defines the observed state of SpecialResource
+            properties:
+              state:
+                type: string
+            required:
+            - state
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/4.9/metadata/annotations.yaml
+++ b/bundle/4.9/metadata/annotations.yaml
@@ -1,0 +1,12 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: "4.9"
+  operators.operatorframework.io.bundle.channels.v1: "4.9"
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: special-resource-operator
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.2.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v2
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1

--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -1,0 +1,13 @@
+updates:
+  - file: "{MAJOR}.{MINOR}/manifests/special-resource-operator.v{MAJOR}.{MINOR}.0.clusterserviceversion.yaml" # relative to this file
+    update_list:
+    - search: "special-resource-operator.v{MAJOR}.{MINOR}.0"
+      replace: "special-resource-operator.{FULL_VER}"
+    - search: "version: {MAJOR}.{MINOR}.0"
+      replace: "version: {FULL_VER}"
+    - search: 'olm.skipRange: ">=4.6.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.6.0 <{FULL_VER}"'
+  - file: "nfd.package.yaml"
+    update_list:
+    - search: "currentCSV: special-resource-operator.v{MAJOR}.{MINOR}.0"
+      replace: "currentCSV: special-resource-operator.{FULL_VER}"

--- a/bundle/special-resource-operator.package.yaml
+++ b/bundle/special-resource-operator.package.yaml
@@ -1,0 +1,5 @@
+packageName: special-resource-operator
+channels:
+- name: '4.9'
+  currentCSV: special-resource-operator.v4.9.0
+defaultChannel: "4.9"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift-psap/special-resource-operator
-  newTag: ping-ping
+  newTag: release-4.9


### PR DESCRIPTION
This is a first draft adding the bundle needed by ART.

This was created with some manual steps that should be integrated into the Makefile (`make bundle`) going forward. 

The steps are:
```bash
make bundle TAG=release-4.9 VERSION=4.9.0
mkdir bundle/4.9
mv bundle/manifests/special-resource-operator.clusterserviceversion.yaml bundle/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml

rm  -rf bundle/tests
mv bundle/manifests bundle/4.9
mv bundle/metadata bundle/4.9
mv bundle.Dockerfile bundle/4.9

vim bundle/4.9/bundle.Dockerfile  #update COPY paths in bundle/4.9/bundle.Dockerfile
```
