### PR TITLE
Updating bundle image name and CRD

### DIFF
--- a/bundle/4.9/manifests/image-references
+++ b/bundle/4.9/manifests/image-references
@@ -5,7 +5,7 @@ spec:
   - name: special-resource-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-special-resource-operator:4.9
+      name: quay.io/openshift/special-resource-rhel8-operator:4.9
   - name: kube-rbac-proxy
     from:
       kind: DockerImage

--- a/bundle/4.9/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml
+++ b/bundle/4.9/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml
@@ -79,6 +79,102 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - nodes/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes/status
+          verbs:
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - deletecollection
+        - apiGroups:
+          - ""
+          resources:
+          - podtemplates
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - podtemplates/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - '*'
+          resources:
+          - cronjobs
+          verbs:
+          - get
+        - apiGroups:
+          - '*'
+          resources:
+          - daemonsets
+          verbs:
+          - get
+        - apiGroups:
+          - '*'
+          resources:
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - '*'
+          resources:
+          - imagepolicies
+          verbs:
+          - get
+        - apiGroups:
+          - '*'
+          resources:
+          - jobs
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - '*'
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+        - apiGroups:
+          - '*'
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - '*'
+          resources:
+          - replicacontrollers
+          verbs:
+          - get
+        - apiGroups:
+          - '*'
+          resources:
+          - replicasets
+          verbs:
+          - get
+        - apiGroups:
+          - '*'
+          resources:
+          - statefulsets
+          verbs:
+          - get
+        - apiGroups:
           - acme.cert-manager.io
           resources:
           - challenges
@@ -137,6 +233,7 @@ spec:
           - delete
           - get
           - list
+          - patch
           - update
           - watch
         - apiGroups:
@@ -148,8 +245,18 @@ spec:
           - delete
           - get
           - list
+          - patch
           - update
           - watch
+        - apiGroups:
+          - admissionregistration.k8s.io/v1beta1
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - create
+          - delete
+          - list
+          - update
         - apiGroups:
           - apiextensions.k8s.io
           resources:
@@ -234,6 +341,18 @@ spec:
           verbs:
           - get
           - list
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
           - update
           - watch
         - apiGroups:
@@ -430,6 +549,12 @@ spec:
           - get
           - list
         - apiGroups:
+          - connaisseur.policy
+          resources:
+          - imagepolicies
+          verbs:
+          - create
+        - apiGroups:
           - coordination.k8s.io
           resources:
           - leases
@@ -571,6 +696,8 @@ spec:
           - delete
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - ""
@@ -642,6 +769,18 @@ spec:
           - csi.storage.k8s.io
           resources:
           - csidrivers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - jobs
           verbs:
           - create
           - delete
@@ -1090,7 +1229,7 @@ spec:
                   value: 0.0.1-snapshot
                 - name: SSL_CERT_DIR
                   value: /etc/pki/tls/certs
-                image: quay.io/openshift-psap/special-resource-operator:release-4.9
+                image: quay.io/openshift/special-resource-rhel8-operator:4.9
                 imagePullPolicy: Always
                 name: manager
                 resources:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,5 +5,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/openshift-psap/special-resource-operator
-  newTag: release-4.9
+  newName: quay.io/openshift/special-resource-rhel8-operator
+  newTag: "4.9"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,102 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - nodes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - podtemplates
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - podtemplates/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - '*'
+  resources:
+  - cronjobs
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - daemonsets
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - imagepolicies
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - jobs
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - replicacontrollers
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - replicasets
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - statefulsets
+  verbs:
+  - get
+- apiGroups:
   - acme.cert-manager.io
   resources:
   - challenges
@@ -65,6 +161,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -76,8 +173,18 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
+- apiGroups:
+  - admissionregistration.k8s.io/v1beta1
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - list
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -162,6 +269,18 @@ rules:
   verbs:
   - get
   - list
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -358,6 +477,12 @@ rules:
   - get
   - list
 - apiGroups:
+  - connaisseur.policy
+  resources:
+  - imagepolicies
+  verbs:
+  - create
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -499,6 +624,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -570,6 +697,18 @@ rules:
   - csi.storage.k8s.io
   resources:
   - csidrivers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - jobs
   verbs:
   - create
   - delete


### PR DESCRIPTION
This PR updates the bundle since there have been a few RBAC changes to the CRD. It also uses the new correct image name for the CSV so that ART can (hopefully) start building images.