### PR TITLE
Add support for Veritas InfoScale driver container

### DIFF
--- a/charts/infoscale/infoscale-vtas-0.0.1/Chart.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: infoscale-vtas
+description: A Helm chart for the deployment of Veritas InfoScale Resources
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "8.0.0.0000"

--- a/charts/infoscale/infoscale-vtas-0.0.1/infoscale-vtas.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/infoscale-vtas.yaml
@@ -1,0 +1,40 @@
+apiVersion: sro.openshift.io/v1beta1
+kind: SpecialResource
+metadata:
+  name: infoscale-vtas
+spec:
+  namespace: infoscale-vtas
+  chart:
+    name: infoscale-vtas
+    version: 0.0.1
+    repository:
+      name: infoscale
+      url: file:///charts/infoscale
+  set:
+    kind: Values
+    apiVersion: sro.openshift.io/v1beta1
+    runArgs:
+      infoscaleConfigMap: "infoscalecluster-dev-configmap"
+      infoscaleImage: "veritas/infoscale:8.0.0.0000"
+      infoscaleCSIPlugin: "veritas/infoscale_csi_plugin:2.0.0.0000"
+      infoscaleFenImage: "veritas/infoscale-vxfen:2.0.0.0000"
+      infoscaleLicImage: "veritas/infoscale-license:8.0.0.0000"
+      infoscaleImgPullPolicy: "IfNotPresent"
+      infoscaleCSIImgPullPolicy: "IfNotPresent"
+      infoscaleFenImgPullPolicy: "IfNotPresent"
+      infoscaleLicImgPullPolicy: "IfNotPresent"
+      csiAttacher: "openshift4/ose-csi-external-attacher"
+      csiProvisioner: "openshift4/ose-csi-external-provisioner-rhel8"
+      csiRegistrar: "openshift4/ose-csi-driver-registrar"
+      csiResizer: "openshift4/ose-csi-external-resizer-rhel8"
+      csiSnapshotter: "openshift4/ose-csi-external-snapshotter-rhel8"
+      fenController: "kube-fencing-controller:v2.1.0"
+      fenSwitcher: "kube-fencing-switcher:v2.1.0"
+      licPort: "6443"
+      licServer: "192.68.42.56"
+      licUUID: "691c169d-a714-4d27-b46b-a1213a5df662"
+      terminationPeriod: "200"
+      infoscaleVersion: "8.0.0.0000"
+      platform: "openshift-container-platform"
+    node:
+      selector: "IS-cluster1"

--- a/charts/infoscale/infoscale-vtas-0.0.1/templates/1000-license-container.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/templates/1000-license-container.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-licensing-controller
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-licensing-controller
+rules:
+  {{- if eq .Values.runArgs.platform "openshift-container-platform" }}
+  - apiGroups:
+    - security.openshift.io
+    resources:
+    - securitycontextconstraints
+    verbs:
+    - use
+    resourceNames:
+    - {{.Values.specialresource.metadata.name}}-licensing-controller
+  {{- end }}
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-licensing-controller
+roleRef:
+  kind: ClusterRole
+  name: {{.Values.specialresource.metadata.name}}-licensing-controller
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{.Values.specialresource.metadata.name}}-licensing-controller
+  namespace: {{.Values.specialresource.spec.namespace}}
+
+---
+
+{{- if eq .Values.runArgs.platform "openshift-container-platform" }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: Custom SCC
+    release.openshift.io/create-only: "true"
+  name: {{.Values.specialresource.metadata.name}}-licensing-controller
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: MustRunAs
+  uid: 1005
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{.Values.specialresource.spec.namespace}}:{{.Values.specialresource.metadata.name}}-licensing-controller
+
+---
+{{- end }}
+
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{.Values.specialresource.metadata.name}}-licensing-controller
+  name: {{.Values.specialresource.metadata.name}}-licensing-controller
+  annotations:
+    specialresource.openshift.io/wait: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{.Values.specialresource.metadata.name}}-licensing-controller
+  template:
+    metadata:
+      labels:
+        app: {{.Values.specialresource.metadata.name}}-licensing-controller
+    spec:
+      serviceAccount: {{.Values.specialresource.metadata.name}}-licensing-controller
+      serviceAccountName: {{.Values.specialresource.metadata.name}}-licensing-controller
+      containers:
+        - name: {{.Values.specialresource.metadata.name}}-licensing-controller
+          image: {{.Values.runArgs.infoscaleLicImage}}-{{.Values.operatingSystemMajor}}
+          securityContext:
+            runAsUser: 1005
+          imagePullPolicy: {{.Values.runArgs.infoscaleLicImgPullPolicy}}
+          command: [ "/sbin/lic-entrypoint.sh" ]
+          args:
+          - "--hostname={{.Values.runArgs.licServer}}"
+          - "--port={{.Values.runArgs.licPort}}"
+          - "--uuid={{.Values.runArgs.licUUID}}"
+          env:
+            - name: product_version
+              value: "{{.Values.runArgs.infoscaleVersion}}"
+          readinessProbe:
+            exec:
+              command: [ "/bin/sh", "-c", "/opt/VRTSvlic/tele/bin/TelemetryCollector -status | grep 'Running'" ]
+            initialDelaySeconds: 30
+            periodSeconds: 45
+            timeoutSeconds: 5
+      nodeSelector:
+        {{.Values.node.selector}}: "true"

--- a/charts/infoscale/infoscale-vtas-0.0.1/templates/2000-infoscale-rest-certificate.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/templates/2000-infoscale-rest-certificate.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-rest-cert
+  annotations:
+     specialresource.openshift.io/wait: "true"
+spec:
+  serviceAccount: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+  dnsNames:
+    - {{.Values.specialresource.metadata.name}}-rest.{{.Values.specialresource.spec.namespace}}.svc.cluster.local
+    - {{.Values.specialresource.metadata.name}}-rest.{{.Values.specialresource.spec.namespace}}.svc
+    - {{.Values.specialresource.metadata.name}}-rest.{{.Values.specialresource.spec.namespace}}
+    - {{.Values.specialresource.metadata.name}}-rest
+
+  secretName: rest-tls-cert
+  duration: 8760h # 365d
+  renewBefore: 720h # 30d
+  issuerRef:
+    name: infoscale-cert-issuer

--- a/charts/infoscale/infoscale-vtas-0.0.1/templates/3000-driver-container.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/templates/3000-driver-container.yaml
@@ -1,0 +1,249 @@
+#
+# Note: Service Account for driver container is already created as a part of state file 2000-infoscale-rest-certificate.yaml
+#
+
+{{- if eq .Values.runArgs.platform "openshift-container-platform" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+subjects:
+- kind: ServiceAccount
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+userNames:
+- system:serviceaccount:{{.Values.specialresource.spec.namespace}}:{{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+
+---
+
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- '*'
+allowedUnsafeSysctls:
+- '*'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: Custom SCC similar to privilege SCC-HOSTPID/HOSTIPC
+    release.openshift.io/create-only: "true"
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{.Values.specialresource.spec.namespace}}:{{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+volumes:
+- configMap
+- emptyDir
+- hostPath
+- secret
+
+---
+{{- end }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-rest
+  annotations:
+     specialresource.openshift.io/wait: "true"
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8443
+    targetPort: 9443
+    protocol: TCP
+  selector:
+    {{.Values.node.selector}}: "true"
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+    {{.Values.node.selector}}: "true"
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+  annotations:
+    {{- if eq .Values.runArgs.platform "openshift-container-platform" }}
+    openshift.io/scc: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+    {{- end }}
+    specialresource.openshift.io/wait: "true"
+    specialresource.openshift.io/state: "driver-container"
+    specialresource.openshift.io/driver-container-vendor: infoscale-vtas
+spec:
+  selector:
+    matchLabels:
+      app: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+      {{.Values.node.selector}}: "true"
+  updateStrategy:
+    type: OnDelete
+  template:
+    metadata:
+      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
+      # reserves resources for critical add-on pods so that they can be rescheduled after
+      # a failure.  This annotation works in tandem with the toleration below.
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        app: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+        {{.Values.node.selector}}: "true"
+    spec:
+      serviceAccount: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+      serviceAccountName: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+      hostPID: false
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - image: {{.Values.runArgs.infoscaleImage}}-{{.Values.operatingSystemMajorMinor}}-{{.Values.kernelFullVersion}}
+        imagePullPolicy: {{.Values.runArgs.infoscaleImgPullPolicy}}
+        name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.driverContainer}}-{{.Values.operatingSystemMajor}}
+        securityContext:
+          privileged: true
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh","-c","/sbin/vss-stop"]
+        readinessProbe:
+          exec:
+            command: ["/bin/sh", "-c", "/sbin/vss-readiness"]
+          initialDelaySeconds: 30
+          periodSeconds: 45
+        terminationMessagePath: /tmp/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /dev
+          name: dev
+          mountPropagation: "Bidirectional"
+        - mountPath: /var/lib/kubelet/plugins
+          name: csi-stage
+          mountPropagation: "Bidirectional"
+        - name: vss-config
+          mountPath: "/vss-config"
+          readOnly: true
+        - name: cert-dir
+          mountPath: /etc/vx/certstore/rest
+        - name: log-sys
+          mountPath: /var/log
+        - name: log-vxfs
+          mountPath: /var/VRTSvxfs
+        - name: log-vcs
+          mountPath: /var/VRTSvcs/log
+        - name: log-rest
+          mountPath: /opt/VRTSrest/log
+        - name: log-veki
+          mountPath: /var/VRTSveki
+        - name: log-vras
+          mountPath: /var/vx/vras/log
+        - name: log-vxvm
+          mountPath: /var/adm/vx
+        - name: log-vxconfigd
+          mountPath: /etc/vx/vxconfigd.log
+        - name: log-vss
+          mountPath: /var/VRTSvss
+        - name: log-installer
+          mountPath: /opt/VRTS/install/logs
+      terminationGracePeriodSeconds: {{.Values.runArgs.terminationPeriod}}
+      restartPolicy: Always
+      tolerations:
+        - effect: NoSchedule
+          key: veritas/infoscale-upgrade
+          operator: Exists
+      volumes:
+        - name: dev
+          hostPath:
+              path: /dev
+              type: Directory
+        - name: csi-stage
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: Directory
+        - name: vss-config
+          configMap:
+              name: {{.Values.runArgs.infoscaleConfigMap}}
+              defaultMode: 0700
+        - name: cert-dir
+          secret:
+              secretName: rest-tls-cert
+
+# Creating separate hostpath volume for each log destination
+        - name: log-sys
+          hostPath:
+              path: /var/VRTS/log/var/log
+              type: DirectoryOrCreate
+        - name: log-vxfs
+          hostPath:
+              path: /var/VRTS/log/var/VRTSvxfs
+              type: DirectoryOrCreate
+        - name: log-vcs
+          hostPath:
+              path: /var/VRTS/log/var/VRTSvcs/log
+              type: DirectoryOrCreate
+        - name: log-rest
+          hostPath:
+              path: /var/VRTS/log/opt/VRTSrest/log
+              type: DirectoryOrCreate
+        - name: log-veki
+          hostPath:
+              path: /var/VRTS/log/var/VRTSveki
+              type: DirectoryOrCreate
+        - name: log-vras
+          hostPath:
+              path: /var/VRTS/log/var/vx/vras/log
+              type: DirectoryOrCreate
+        - name: log-vxvm
+          hostPath:
+              path: /var/VRTS/log/var/adm/vx
+              type: DirectoryOrCreate
+        - name: log-vxconfigd
+          hostPath:
+              path: /var/VRTS/log/var/adm/vx/vxconfigd.log
+              type: FileOrCreate
+        - name: log-vss
+          hostPath:
+              path: /var/VRTS/log/var/VRTSvss
+              type: DirectoryOrCreate
+        - name: log-installer
+          hostPath:
+              path: /var/VRTS/log/opt/VRTS/install/logs
+              type: DirectoryOrCreate
+      nodeSelector:
+        feature.node.kubernetes.io/kernel-version.full: "{{.Values.kernelFullVersion}}"
+        {{.Values.node.selector}}: "true"

--- a/charts/infoscale/infoscale-vtas-0.0.1/templates/4000-infoscale-fencing-certificate.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/templates/4000-infoscale-fencing-certificate.yaml
@@ -1,0 +1,28 @@
+#Service account for fencing pod
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-fencing
+  namespace: {{.Values.specialresource.spec.namespace}}
+
+---
+
+#Certificate for fencing pod
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-vxfen-cert
+  namespace: {{.Values.specialresource.spec.namespace}}
+  annotations:
+     specialresource.openshift.io/wait: "true"
+spec:
+  serviceAccount: {{.Values.specialresource.metadata.name}}-fencing
+  commonName: {{.Values.specialresource.metadata.name}}-vxfen
+  secretName: vxfen-tls-cert
+  duration: 8760h # 365d
+  renewBefore: 720h # 30d
+  issuerRef:
+    name: infoscale-cert-issuer
+    kind: Issuer
+
+---

--- a/charts/infoscale/infoscale-vtas-0.0.1/templates/4100-infoscale-fencing-driver.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/templates/4100-infoscale-fencing-driver.yaml
@@ -1,0 +1,247 @@
+---
+# Source: kube-fencing/templates/controller-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-fencing-controller
+  namespace: {{.Values.specialresource.spec.namespace}}
+---
+# Source: kube-fencing/templates/switcher-rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-fencing-switcher
+  namespace: {{.Values.specialresource.spec.namespace}}
+---
+
+{{- if eq .Values.runArgs.platform "openshift-container-platform" }}
+#Custom SCC to allow hostNetwork
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: Custom SCC for host network access
+    release.openshift.io/create-only: "true"
+  name: infoscale-kubefencing-scc
+allowHostNetwork: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{.Values.specialresource.spec.namespace}}:{{.Values.specialresource.metadata.name}}-fencing-switcher
+- system:serviceaccount:{{.Values.specialresource.spec.namespace}}:{{.Values.specialresource.metadata.name}}-fencing-controller
+
+---
+{{- end }}
+
+# Source: kube-fencing/templates/controller-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-fencing-controller
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "watch", "get", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "get", "delete", "deletecollection"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["list", "watch", "get", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["podtemplates"]
+    verbs: ["list", "watch", "get"]
+  - apiGroups: [""]
+    resources: ["podtemplates/finalizers", "nodes/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["list", "watch", "get", "delete"]
+---
+# Source: kube-fencing/templates/switcher-rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-fencing-switcher
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["patch"]
+---
+# Source: kube-fencing/templates/controller-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-fencing-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{.Values.specialresource.metadata.name}}-fencing-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{.Values.specialresource.metadata.name}}-fencing-controller
+    namespace: {{.Values.specialresource.spec.namespace}}
+---
+# Source: kube-fencing/templates/switcher-rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-fencing-switcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{.Values.specialresource.metadata.name}}-fencing-switcher
+subjects:
+  - kind: ServiceAccount
+    name: {{.Values.specialresource.metadata.name}}-fencing-switcher
+    namespace: {{.Values.specialresource.spec.namespace}}
+---
+# Source: kube-fencing/templates/switcher-daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: {{.Values.specialresource.metadata.name}}-fencing-switcher
+  name: {{.Values.specialresource.metadata.name}}-fencing-switcher
+  namespace: {{.Values.specialresource.spec.namespace}}
+  annotations:
+    specialresource.openshift.io/wait: "true"
+spec:
+  selector:
+    matchLabels:
+      app: {{.Values.specialresource.metadata.name}}-fencing-switcher
+  template:
+    metadata:
+      labels:
+        app: {{.Values.specialresource.metadata.name}}-fencing-switcher
+    spec:
+      serviceAccountName: {{.Values.specialresource.metadata.name}}-fencing-switcher
+      hostNetwork: true
+      imagePullSecrets:
+        - name: regsecret
+      containers:
+      - name: switcher
+        image: {{.Values.runArgs.fenSwitcher}}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      nodeSelector:
+        {{.Values.node.selector}}: "true"
+---
+# Source: kube-fencing/templates/controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{.Values.specialresource.metadata.name}}-fencing-controller
+  name: {{.Values.specialresource.metadata.name}}-fencing-controller
+  namespace: {{.Values.specialresource.spec.namespace}}
+  annotations:
+    specialresource.openshift.io/wait: "true"
+spec:
+  replicas:
+  selector:
+    matchLabels:
+      app: {{.Values.specialresource.metadata.name}}-fencing-controller
+  template:
+    metadata:
+      labels:
+        app: {{.Values.specialresource.metadata.name}}-fencing-controller
+    spec:
+      serviceAccountName: {{.Values.specialresource.metadata.name}}-fencing-controller
+      hostNetwork: true
+      imagePullSecrets:
+        - name: regsecret
+      terminationGracePeriodSeconds: 0
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 0
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 0
+      containers:
+      - name: controller
+        image: {{.Values.runArgs.fenController}}
+        imagePullPolicy: IfNotPresent
+      nodeSelector:
+        {{.Values.node.selector}}: "true"
+---
+
+{{- if eq .Values.runArgs.platform "openshift-container-platform" }}
+#SCC for fencing service account
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: Custom SCC for volume access
+    release.openshift.io/create-only: "true"
+  name: infoscale-fencing-scc
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{.Values.specialresource.spec.namespace}}:{{.Values.specialresource.metadata.name}}-fencing
+volumes:
+- secret
+
+---
+{{- end }}
+
+#fencing pod tempalte
+apiVersion: v1
+kind: PodTemplate
+metadata:
+  name: fencing
+  namespace: {{.Values.specialresource.spec.namespace}}
+  annotations:
+    specialresource.openshift.io/wait: "true"
+    fencing/ttl: '0'
+template:
+  spec:
+    serviceAccountName: {{.Values.specialresource.metadata.name}}-fencing
+    containers:
+    - name: fence
+      image: {{.Values.runArgs.infoscaleFenImage}}-{{.Values.operatingSystemMajor}}
+      imagePullPolicy: {{.Values.runArgs.infoscaleFenImgPullPolicy}}
+      command: ["vxfenrestcli", "-N", "$(FENCING_NODE)", "-u", "https://{{.Values.specialresource.metadata.name}}-rest:8443"]
+      volumeMounts:
+        - name: cert-dir
+          mountPath: /etc/vx/certstore/vxfen
+          readOnly: true
+      env:
+      - name: FENCING_NODE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.annotations['fencing/node']
+      - name: FENCING_ID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.annotations['fencing/id']
+    volumes:
+        - name: cert-dir
+          secret:
+            secretName: vxfen-tls-cert
+    restartPolicy: OnFailure
+    nodeSelector:
+      {{.Values.node.selector}}: "true"

--- a/charts/infoscale/infoscale-vtas-0.0.1/templates/5000-infoscale-csi-certificate.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/templates/5000-infoscale-csi-certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+ name: {{.Values.specialresource.metadata.name}}-csi-cert
+ annotations:
+     specialresource.openshift.io/wait: "true"
+spec:
+ commonName: csi-plugin
+ secretName: csi-tls-cert
+ duration: 8760h # 365d
+ renewBefore: 720h # 30d
+ issuerRef:
+   name: infoscale-cert-issuer

--- a/charts/infoscale/infoscale-vtas-0.0.1/templates/6000-infoscale-csi-driver.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/templates/6000-infoscale-csi-driver.yaml
@@ -1,0 +1,510 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+
+---
+
+{{- if eq .Values.runArgs.platform "openshift-container-platform" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+subjects:
+- kind: ServiceAccount
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+userNames:
+- system:serviceaccount:{{.Values.specialresource.spec.namespace}}:{{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+
+---
+{{- end }}
+
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+
+---
+
+{{- if eq .Values.runArgs.platform "openshift-container-platform" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+subjects:
+- kind: ServiceAccount
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+userNames:
+- system:serviceaccount:{{.Values.specialresource.spec.namespace}}:{{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+
+---
+{{- end }}
+
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: info-config
+data:
+  # Update this value with InfoScale REST server ip and port in your environment
+    INFOSCALE_REST_URL: https://{{.Values.specialresource.metadata.name}}-rest:8443
+  # Update this value based on InfoScale diskgroup name used in your environment
+    INFOSCALE_DISKGROUP_NAME: "vrts_kube_dg"
+
+---
+
+{{- if eq .Values.runArgs.platform "openshift-container-platform" }}
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: Custom SCC similar to privilege SCC-HOSTPID/HOSTIPC
+    release.openshift.io/create-only: "true"
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{.Values.specialresource.spec.namespace}}:{{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+volumes:
+- emptyDir
+- secret
+
+---
+
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: true
+allowedCapabilities:
+- 'SYS_ADMIN'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: Custom SCC similar to privilege SCC-HOSTPID/HOSTIPC
+    release.openshift.io/create-only: "true"
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{.Values.specialresource.spec.namespace}}:{{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+volumes:
+- hostPath
+- secret
+
+---
+{{- end }}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-csi-role
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims/status"]
+  verbs: ["patch", "update"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotcontents"]
+  verbs: ["create", "get", "list", "watch", "update", "delete"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots/status"]
+  verbs: ["update"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotcontents/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments"]
+  verbs: ["get", "list", "watch", "update", "patch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["list", "watch", "create", "update", "patch", "delete", "get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["csinodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "list", "watch", "create", "update"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create", "list", "watch", "delete"]
+- apiGroups: ["csi.storage.k8s.io"]
+  resources: ["csidrivers"]
+  verbs: ["create", "delete"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-csi-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{.Values.specialresource.metadata.name}}-csi-role
+subjects:
+- kind: ServiceAccount
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+  namespace: {{.Values.specialresource.spec.namespace}}
+
+---
+
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: org.veritas.infoscale
+spec:
+  attachRequired: false
+  podInfoOnMount: false
+  fsGroupPolicy: File
+
+---
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+  labels:
+    app: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+  annotations:
+    specialresource.openshift.io/wait: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+  template:
+    metadata:
+      labels:
+        app: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+    spec:
+      containers:
+      - name: csi-provisioner
+        image: {{.Values.runArgs.csiProvisioner}}
+        args:
+        - "--v=5"
+        - "--csi-address=$(ADDRESS)"
+        - "--timeout=60s"
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-attacher
+        image: {{.Values.runArgs.csiAttacher}}
+        args:
+        - "--v=5"
+        - "--csi-address=$(ADDRESS)"
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-resizer
+        image: {{.Values.runArgs.csiResizer}}
+        args:
+        - "--v=5"
+        - "--csi-address=$(ADDRESS)"
+        - "--timeout=30s"
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-snapshotter
+        image: {{.Values.runArgs.csiSnapshotter}}
+        args:
+        - "--v=5"
+        - "--csi-address=$(ADDRESS)"
+        env:
+        - name: ADDRESS
+          value: /var/lib/csi/sockets/pluginproxy/csi.sock
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: socket-dir
+          mountPath: /var/lib/csi/sockets/pluginproxy/
+      - name: csi-infoscale-plugin
+        image: {{.Values.runArgs.infoscaleCSIPlugin}}-{{.Values.operatingSystemMajor}}
+        args:
+        - "--endpoint=$(CSI_ENDPOINT)"
+        - "--nodeid=$(NODE_ID)"
+        - "--url=$(INFOSCALE_REST_URL)"
+        - "--dgname=$(INFOSCALE_DISKGROUP_NAME)"
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: INFOSCALE_REST_URL
+          valueFrom:
+            configMapKeyRef:
+              name: info-config
+              key: INFOSCALE_REST_URL
+        - name: INFOSCALE_AUTH_KEYSTORE
+          value: /etc/vx/csi/certs/
+        - name: INFOSCALE_DISKGROUP_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: info-config
+              key: INFOSCALE_DISKGROUP_NAME
+        imagePullPolicy: {{.Values.runArgs.infoscaleCSIImgPullPolicy}}
+        volumeMounts:
+          - name: socket-dir
+            mountPath: /var/lib/csi/sockets/pluginproxy/
+          - mountPath: /etc/vx/csi/certs
+            name: csi-cert
+            readOnly: true
+
+      volumes:
+      - name: socket-dir
+        emptyDir: {}
+      - name: csi-cert
+        secret:
+          secretName: csi-tls-cert
+
+      serviceAccount: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-controller
+      nodeSelector:
+        {{.Values.node.selector}}: "true"
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+  name: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+  annotations:
+    {{- if eq .Values.runArgs.platform "openshift-container-platform" }}
+    openshift.io/scc: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+    {{- end }}
+    specialresource.openshift.io/wait: "true"
+spec:
+  selector:
+    matchLabels:
+      app: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+  template:
+    metadata:
+      labels:
+        app: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+    spec:
+      serviceAccount: {{.Values.specialresource.metadata.name}}-{{.Values.groupName.csiDriver}}-node
+      containers:
+      - name: csi-infoscale-plugin
+        image: {{.Values.runArgs.infoscaleCSIPlugin}}-{{.Values.operatingSystemMajor}}
+        imagePullPolicy: {{.Values.runArgs.infoscaleCSIImgPullPolicy}}
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+          allowPrivilegeEscalation: true
+        command: [ "/sbin/csi-node-entrypoint.sh" ]
+        args:
+        - "--endpoint=$(CSI_ENDPOINT)"
+        - "--nodeid=$(NODE_ID)"
+        - "--url=$(INFOSCALE_REST_URL)"
+        - "--dgname=$(INFOSCALE_DISKGROUP_NAME)"
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:/csi/csi.sock
+        - name: INFOSCALE_AUTH_KEYSTORE
+          value: /etc/vx/csi/certs/
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: INFOSCALE_REST_URL
+          valueFrom:
+            configMapKeyRef:
+              name: info-config
+              key: INFOSCALE_REST_URL
+        - name: INFOSCALE_DISKGROUP_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: info-config
+              key: INFOSCALE_DISKGROUP_NAME
+        terminationMessagePath: /tmp/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - name: plugin-dir
+            mountPath: /csi
+          - name: pods-mount-dir
+            mountPath: /var/lib/kubelet
+            mountPropagation: "Bidirectional"
+          - name: host-dev
+            mountPath: /dev
+            mountPropagation: "HostToContainer"
+            mountPropagation: "Bidirectional"
+          - name: host-sys
+            mountPath: /sys
+            mountPropagation: "HostToContainer"
+          - mountPath: /etc/vx/csi/certs
+            name: csi-cert
+            readOnly: true
+          - name: node-feature-discovery
+            mountPath: /etc/kubernetes/node-feature-discovery/
+            mountPropagation: "Bidirectional"
+      - name: csi-node-driver-registrar
+        image: {{.Values.runArgs.csiRegistrar}}
+        args:
+          - "--csi-address=$(ADDRESS)"
+          - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          - "--v=5"
+        lifecycle:
+          preStop:
+            exec:
+              command: [
+                "/bin/sh", "-c",
+                "rm -rf /registration/org.veritas.infoscale \
+                 /registration/org.veritas.infoscale-reg.sock"
+              ]
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/org.veritas.infoscale/csi.sock
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+        - name: registration-dir
+          mountPath: /registration
+      securityContext:
+        runAsGroup: 0
+        runAsUser: 0
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/org.veritas.infoscale
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: host-dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: host-sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: node-feature-discovery
+          hostPath:
+            path: /etc/kubernetes/node-feature-discovery/
+            type: Directory
+        - name: csi-cert
+          secret:
+            secretName: csi-tls-cert
+      nodeSelector:
+        {{.Values.node.selector}}: "true"

--- a/charts/infoscale/infoscale-vtas-0.0.1/values.yaml
+++ b/charts/infoscale/infoscale-vtas-0.0.1/values.yaml
@@ -1,0 +1,41 @@
+# Default values for infoScale-vtas.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+specialresource:
+  metadata:
+    name: "infoscale-vtas"
+  spec:
+    namespace: "infoscale-vtas"
+    drivercontainer:
+      source:
+        git:
+          ref: "ref"
+          uri: "uri"
+
+runArgs:
+  infoscaleConfigMap: "infoscalecluster-dev-configmap"
+  infoscaleImage: "veritas/infoscale:8.0.0.0000"
+  infoscaleCSIPlugin: "veritas/infoscale_csi_plugin:2.0.0.0000"
+  infoscaleFenImage: "veritas/infoscale-vxfen:2.0.0.0000"
+  infoscaleLicImage: "veritas/infoscale-license:8.0.0.0000"
+  infoscaleImgPullPolicy: "IfNotPresent"
+  infoscaleCSIImgPullPolicy: "IfNotPresent"
+  infoscaleFenImgPullPolicy: "IfNotPresent"
+  infoscaleLicImgPullPolicy: "IfNotPresent"
+  csiAttacher: "openshift4/ose-csi-external-attacher"
+  csiProvisioner: "openshift4/ose-csi-external-provisioner-rhel8"
+  csiRegistrar: "openshift4/ose-csi-driver-registrar"
+  csiResizer: "openshift4/ose-csi-external-resizer-rhel8"
+  csiSnapshotter: "openshift4/ose-csi-external-snapshotter-rhel8"
+  fenController: "kube-fencing-controller:v2.1.0"
+  fenSwitcher: "kube-fencing-switcher:v2.1.0"
+  licPort: "6443"
+  licServer: "192.68.42.56"
+  licUUID: "691c169d-a714-4d27-b46b-a1213a5df662"
+  terminationPeriod: "200"
+  infoscaleVersion: "8.0.0.0000"
+  platform: "openshift-container-platform"
+
+node:
+  selector: "IS-cluster1"


### PR DESCRIPTION
Tested that InfoScale driver container deployment happens successfully on OpenShift cluster

# oc get pods -n infoscale-vtas
NAME                                                                        READY STATUS RESTARTS AGE
controller-manager-c6ffc687-wggnn                           1/1 Running 0 113m
infoscale-vtas-csi-driver-controller-0                           5/5 Running 0 65m
infoscale-vtas-csi-driver-node-7lm79                           2/2 Running 0 78m
infoscale-vtas-csi-driver-node-gmf8f                           2/2 Running 0 78m
infoscale-vtas-driver-container-rhel8-7lcfz                  1/1 Running 0 108m
infoscale-vtas-driver-container-rhel8-pgvtd                1/1 Running 0 108m
infoscale-vtas-fencing-controller-5f85546ccf-qf946    1/1 Running 0 78m
infoscale-vtas-fencing-switcher-k8vhd                         1/1 Running 0 79m
infoscale-vtas-fencing-switcher-rdb5k                          1/1 Running 0 79m
infoscale-vtas-licensing-controller-5ccc5ddfbc-nq457 1/1 Running 0 108m