### PR TITLE
Update alm-examples in CSV, update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - zvonkok
+  - dagrayvid
 reviewers:
   - zvonkok
   - courtneypacheco

--- a/bundle/4.9/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml
+++ b/bundle/4.9/manifests/special-resource-operator.v4.9.0.clusterserviceversion.yaml
@@ -11,32 +11,15 @@ metadata:
             "name": "simple-kmod"
           },
           "spec": {
-            "configuration": [
-              {
-                "name": "KMOD_NAMES",
-                "value": [
-                  "simple-kmod",
-                  "simple-procfs-kmod"
-                ]
-              }
-            ],
-            "dependsOn": [
-              {
-                "imageReference": "true",
-                "name": "driver-container-base"
-              }
-            ],
+            "chart": {
+              "name": "simple-kmod",
+              "repository": {
+                "name": "example",
+                "url": "file:///charts/example"
+              },
+              "version": "0.0.1"
+            },
             "driverContainer": {
-              "buildArgs": [
-                {
-                  "name": "KVER",
-                  "value": "{{.Values.kernelFullVersion}}"
-                },
-                {
-                  "name": "KMODVER",
-                  "value": "SRO"
-                }
-              ],
               "source": {
                 "git": {
                   "ref": "master",
@@ -44,7 +27,21 @@ metadata:
                 }
               }
             },
-            "namespace": "simple-kmod"
+            "namespace": "simple-kmod",
+            "set": {
+              "apiVersion": "sro.openshift.io/v1beta1",
+              "buildArgs": [
+                {
+                  "name": "KMODVER",
+                  "value": "SRO"
+                }
+              ],
+              "kind": "Values",
+              "kmodNames": [
+                "simple-kmod",
+                "simple-procfs-kmod"
+              ]
+            }
           }
         }
       ]

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,5 +5,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/openshift-psap/special-resource-operator
-  newTag: chart-as-asset
+  newName: quay.io/openshift/special-resource-rhel8-operator
+  newTag: "4.9"

--- a/config/samples/sro_v1beta1_specialresource.yaml
+++ b/config/samples/sro_v1beta1_specialresource.yaml
@@ -4,20 +4,21 @@ metadata:
   name: simple-kmod
 spec:
   namespace: simple-kmod
-  configuration:
-    - name: "KMOD_NAMES"
-      value: ["simple-kmod", "simple-procfs-kmod"]
+  chart:
+    name: simple-kmod
+    version: 0.0.1
+    repository:
+      name: example
+      url: file:///charts/example
+  set:
+    kind: Values
+    apiVersion: sro.openshift.io/v1beta1
+    kmodNames: ["simple-kmod", "simple-procfs-kmod"]
+    buildArgs:
+    - name: "KMODVER"
+      value: "SRO"
   driverContainer:
     source:
       git:
         ref: "master"
         uri: "https://github.com/openshift-psap/kvc-simple-kmod.git"
-    buildArgs:
-      - name: "KVER"
-        value: "{{.Values.kernelFullVersion}}"
-      - name: "KMODVER"
-        value: "SRO"
-
-  dependsOn:
-    - name: "driver-container-base"
-      imageReference: "true"


### PR DESCRIPTION
This PR should address BZ [Bug 1986713](https://bugzilla.redhat.com/show_bug.cgi?id=1986713). 
The `config/samples/sro_v1beta1_specialresource.yaml `was not updated to the latest version of the simple-kmod.yaml CR, so the example CR on operatorhub was missing some required fields. 

Note: I tried to make this file a symlink to `charts/example/simple-kmod-0.0.1/simple-kmod.yaml` to keep them in sync however this seems to break operator-sdk/`make bundle`. (almost all of the manifests created by make bundle were empty/deleted). This is a separate issue to investigate later.

This PR also will give me the power to /approve, which I will do my best to use responsibly :).