### PR TITLE
Allow the pullSecret artifact to be empty

### DIFF
--- a/api/v1beta1/specialresource_types.go
+++ b/api/v1beta1/specialresource_types.go
@@ -27,7 +27,7 @@ type SpecialResourceImages struct {
 	Name       string                 `json:"name"`
 	Kind       string                 `json:"kind"`
 	Namespace  string                 `json:"namespace"`
-	PullSecret string                 `json:"pullsecret"`
+	PullSecret string                 `json:"pullsecret,omitempty"`
 	Paths      []SpecialResourcePaths `json:"path"`
 }
 

--- a/bundle/4.9/manifests/sro.openshift.io_specialresources.yaml
+++ b/bundle/4.9/manifests/sro.openshift.io_specialresources.yaml
@@ -182,7 +182,6 @@ spec:
                           - name
                           - namespace
                           - path
-                          - pullsecret
                           type: object
                         type: array
                     type: object

--- a/config/crd/bases/sro.openshift.io_specialresources.yaml
+++ b/config/crd/bases/sro.openshift.io_specialresources.yaml
@@ -184,7 +184,6 @@ spec:
                           - name
                           - namespace
                           - path
-                          - pullsecret
                           type: object
                         type: array
                     type: object


### PR DESCRIPTION
This commit remove the required from the pullSecret field.

Base on the build documentation the pullSecret is option, if not provided it will use the default builder
serviceAccount

https://docs.openshift.com/container-platform/4.8/cicd/builds/creating-build-inputs.html#builds-image-source_creating-build-inputs

Signed-off-by: Sebastian Sch <sebassch@gmail.com>