### PR TITLE
Fix multiple charts in one configmap

### DIFF
--- a/.patches/getter.patch.go
+++ b/.patches/getter.patch.go
@@ -91,8 +91,10 @@ func (g *ConfigMapGetter) Get(href string, option ...Option) (*bytes.Buffer, err
 		return bytes.NewBuffer([]byte(asciiData["index.yaml"])), nil
 	}
 
-	for _, v := range binaryData {
-		return bytes.NewBuffer(v), nil
+	for k, v := range binaryData {
+		if s[2] == k {
+			return bytes.NewBuffer(v), nil
+		}
 	}
 
 	return nil, errors.New(fmt.Sprintf("Cannot find any asciiData | binaryData in CM %+v\n", chart))

--- a/vendor/helm.sh/helm/v3/pkg/getter/getter.patch.go
+++ b/vendor/helm.sh/helm/v3/pkg/getter/getter.patch.go
@@ -91,8 +91,10 @@ func (g *ConfigMapGetter) Get(href string, option ...Option) (*bytes.Buffer, err
 		return bytes.NewBuffer([]byte(asciiData["index.yaml"])), nil
 	}
 
-	for _, v := range binaryData {
-		return bytes.NewBuffer(v), nil
+	for k, v := range binaryData {
+		if s[2] == k {
+			return bytes.NewBuffer(v), nil
+		}
 	}
 
 	return nil, errors.New(fmt.Sprintf("Cannot find any asciiData | binaryData in CM %+v\n", chart))


### PR DESCRIPTION
This commit fix and issue when there are multiple charts tgz in one configmap.

```
apiVersion: v1
binaryData:
  dpdk-kni-driver-0.0.1.tgz: .....
  iavf-driver-0.0.1.tgz: .....
  ice-driver-0.0.1.tgz: .....
data:
  index.yaml: |
    apiVersion: v1
    entries:
      dpdk-kni-driver:
      - apiVersion: v2
        appVersion: 1.0.0
        created: "2021-08-31T13:21:54.255042765-04:00"
        description: Simple out of tree driver building using SRO
        digest: 74db1a39bccac21780b5aa07d1414cf74139db0b9e3c25f3ab918a3525ac1f74
        icon: https://avatars.githubusercontent.com/u/55542927
        name: dpdk-kni-driver
        type: application
        urls:
        - cm://oot-driver/charts/dpdk-kni-driver-0.0.1.tgz
        version: 0.0.1
      iavf-driver:
      - apiVersion: v2
        appVersion: 1.0.0
        created: "2021-08-31T13:21:54.255460101-04:00"
        description: Simple out of tree driver building using SRO
        digest: 3340b764c487b0d65e99c6f3508568b90512794a409409e7b3576508c85e110b
        icon: https://avatars.githubusercontent.com/u/55542927
        name: iavf-driver
        type: application
        urls:
        - cm://oot-driver/charts/iavf-driver-0.0.1.tgz
        version: 0.0.1
      ice-driver:
      - apiVersion: v2
        appVersion: 1.0.0
        created: "2021-08-31T13:21:54.255839124-04:00"
        description: Simple out of tree driver building using SRO
        digest: be3fff26a6d96038ab2dd851789f0201515a74daec7c905097da3cba4d1ed16f
        icon: https://avatars.githubusercontent.com/u/55542927
        name: ice-driver
        type: application
        urls:
        - cm://oot-driver/charts/ice-driver-0.0.1.tgz
        version: 0.0.1
    generated: "2021-08-31T13:21:54.254398197-04:00"
kind: ConfigMap
metadata:
  creationTimestamp: "2021-08-31T17:21:54Z"
  name: charts
  namespace: oot-driver
  resourceVersion: "57179188"
  uid: 84b2bb57-4294-4fb8-920b-00450608a58f

```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>