### PR TITLE
Simplify IsNodeReady in e2e test

### DIFF
--- a/test/e2e/basic/util.go
+++ b/test/e2e/basic/util.go
@@ -289,14 +289,10 @@ func WaitForClusterOperatorCondition(cs *framework.ClientSet, interval, duration
 
 // IsNodeReady helps determine if a given node is ready or not.
 func IsNodeReady(node corev1.Node) bool {
-	found := false
 	for _, condition := range node.Status.Conditions {
 		if condition.Type == corev1.NodeReady {
-			found = true
-			if condition.Status != corev1.ConditionTrue {
-				return false
-			}
+			return condition.Status == corev1.ConditionTrue
 		}
 	}
-	return found
+	return false
 }


### PR DESCRIPTION
As @jmencak noted in #89, there is a more efficient, but equivalent way to write this function in the e2e test.