### PR TITLE
Fix arches in community CSV

### DIFF
--- a/config/manifests/bases/special-resource-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/special-resource-operator.clusterserviceversion.yaml
@@ -11,9 +11,6 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   labels:
     operatorframework.io/arch.amd64: supported
-    operatorframework.io/arch.arm64: supported
-    operatorframework.io/arch.ppc64le: supported
-    operatorframework.io/arch.s390x: supported
   name: special-resource-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
The openshift-psap community image is only built for linux/amd64, while the openshift product image is built for all architectures.  Therefore, these need to be different in each repo based on how they are published.