### PR TITLE
Fix RT kernel DTK setting

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -97,24 +97,21 @@ func NodeVersionInfo() (map[string]NodeVersion, error) {
 }
 
 func UpdateInfo(info map[string]NodeVersion, dtk registry.DriverToolkitEntry, imageURL string) (map[string]NodeVersion, error) {
+	dtk.ImageURL = imageURL
+	osDTK := dtk.OSVersion
 	// Assumes all nodes have the same architecture
 	runningArch := runtime.GOARCH
 	if runningArch == "amd64" {
 		runningArch = "x86_64"
 	}
 	if !strings.Contains(dtk.KernelFullVersion, runningArch) {
-		log.Info("Appending architecture to dtk.KernelFullVersion")
 		dtk.KernelFullVersion = dtk.KernelFullVersion + "." + runningArch
 		dtk.RTKernelFullVersion = dtk.RTKernelFullVersion + "." + runningArch
-		log.Info("Updating version:", "dtk.KernelFullVersion", dtk.KernelFullVersion)
+		log.Info("Updating version:", "dtk.KernelFullVersion", dtk.KernelFullVersion, "dtk.RTKernelFullVersion", dtk.RTKernelFullVersion)
 	}
 
-	// First check for the general kernel entry
 	if _, ok := info[dtk.KernelFullVersion]; ok {
-
-		dtk.ImageURL = imageURL
 		osNFD := info[dtk.KernelFullVersion].OSVersion
-		osDTK := dtk.OSVersion
 
 		if osNFD != osDTK {
 			return nil, fmt.Errorf("OSVersion mismatch NFD: %s vs. DTK: %s", osNFD, osDTK)
@@ -129,10 +126,7 @@ func UpdateInfo(info map[string]NodeVersion, dtk registry.DriverToolkitEntry, im
 	}
 
 	if _, ok := info[dtk.RTKernelFullVersion]; ok {
-
-		dtk.ImageURL = imageURL
 		osNFD := info[dtk.RTKernelFullVersion].OSVersion
-		osDTK := dtk.OSVersion
 
 		if osNFD != osDTK {
 			return nil, fmt.Errorf("OSVersion mismatch NFD: %s vs. DTK: %s", osNFD, osDTK)
@@ -142,7 +136,7 @@ func UpdateInfo(info map[string]NodeVersion, dtk registry.DriverToolkitEntry, im
 		nodeVersion.OSVersion = dtk.OSVersion
 		nodeVersion.DriverToolkit = dtk
 
-		info[dtk.KernelFullVersion] = nodeVersion
+		info[dtk.RTKernelFullVersion] = nodeVersion
 
 	}
 	return info, nil

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -1,0 +1,152 @@
+package upgrade_test
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	"github.com/onsi/gomega"
+	"github.com/openshift-psap/special-resource-operator/pkg/registry"
+	"github.com/openshift-psap/special-resource-operator/pkg/upgrade"
+)
+
+var _ = ginkgo.Describe("pkg/upgrade", func() {
+	ginkgo.Context("UpdateInfo", func() {
+
+		defaultKernelFullVersion := "4.18.0-305.19.1.el8_4"
+		defaultKernelFullVersionArch := defaultKernelFullVersion + ".x86_64"
+		defaultRTKernelFullVersion := "4.18.0-305.19.1.rt7.91.el8_4"
+		defaultRTKernelFullVersionArch := defaultRTKernelFullVersion + ".x86_64"
+		defaultOSVersion := "8.4"
+		defaultClusterVersion := "4.9"
+
+		defaultDTKInput := registry.DriverToolkitEntry{
+			KernelFullVersion:   defaultKernelFullVersion,
+			RTKernelFullVersion: defaultRTKernelFullVersion,
+			OSVersion:           defaultOSVersion,
+		}
+		defaultImageURLInput := "quay.io/somerepo/someimage@sha256:1234567890abcdef"
+
+		ginkgo.When("versions match", func() {
+			testCases := []table.TableEntry{
+				table.Entry(
+					"Regular and RT Kernel",
+					map[string]upgrade.NodeVersion{
+						defaultKernelFullVersionArch: upgrade.NodeVersion{
+							OSVersion:      defaultOSVersion,
+							ClusterVersion: defaultClusterVersion,
+						},
+						defaultRTKernelFullVersionArch: upgrade.NodeVersion{
+							OSVersion:      defaultOSVersion,
+							ClusterVersion: defaultClusterVersion,
+						},
+					},
+					map[string]upgrade.NodeVersion{
+						defaultKernelFullVersionArch: upgrade.NodeVersion{
+							OSVersion:      defaultOSVersion,
+							ClusterVersion: defaultClusterVersion,
+							DriverToolkit: registry.DriverToolkitEntry{
+								ImageURL:            defaultImageURLInput,
+								KernelFullVersion:   defaultKernelFullVersionArch,
+								RTKernelFullVersion: defaultRTKernelFullVersionArch,
+								OSVersion:           defaultOSVersion,
+							},
+						},
+						defaultRTKernelFullVersionArch: upgrade.NodeVersion{
+							OSVersion:      defaultOSVersion,
+							ClusterVersion: defaultClusterVersion,
+							DriverToolkit: registry.DriverToolkitEntry{
+								ImageURL:            defaultImageURLInput,
+								KernelFullVersion:   defaultKernelFullVersionArch,
+								RTKernelFullVersion: defaultRTKernelFullVersionArch,
+								OSVersion:           defaultOSVersion,
+							},
+						},
+					},
+				),
+				table.Entry(
+					"Regular kernel only",
+					map[string]upgrade.NodeVersion{
+						defaultKernelFullVersionArch: upgrade.NodeVersion{
+							OSVersion:      defaultOSVersion,
+							ClusterVersion: defaultClusterVersion,
+						},
+					},
+					map[string]upgrade.NodeVersion{
+						defaultKernelFullVersionArch: upgrade.NodeVersion{
+							OSVersion:      defaultOSVersion,
+							ClusterVersion: defaultClusterVersion,
+							DriverToolkit: registry.DriverToolkitEntry{
+								ImageURL:            defaultImageURLInput,
+								KernelFullVersion:   defaultKernelFullVersionArch,
+								RTKernelFullVersion: defaultRTKernelFullVersionArch,
+								OSVersion:           defaultOSVersion,
+							},
+						},
+					},
+				),
+				table.Entry(
+					"RT kernel only",
+					map[string]upgrade.NodeVersion{
+						defaultRTKernelFullVersionArch: upgrade.NodeVersion{
+							OSVersion:      defaultOSVersion,
+							ClusterVersion: defaultClusterVersion,
+						},
+					},
+					map[string]upgrade.NodeVersion{
+						defaultRTKernelFullVersionArch: upgrade.NodeVersion{
+							OSVersion:      defaultOSVersion,
+							ClusterVersion: defaultClusterVersion,
+							DriverToolkit: registry.DriverToolkitEntry{
+								ImageURL:            defaultImageURLInput,
+								KernelFullVersion:   defaultKernelFullVersionArch,
+								RTKernelFullVersion: defaultRTKernelFullVersionArch,
+								OSVersion:           defaultOSVersion,
+							},
+						},
+					},
+				),
+			}
+			table.DescribeTable("test table", func(input map[string]upgrade.NodeVersion, expected map[string]upgrade.NodeVersion) {
+				info, err := upgrade.UpdateInfo(input, defaultDTKInput, defaultImageURLInput)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gomega.Expect(info).Should(gomega.Equal(expected))
+			}, testCases...)
+		})
+
+		ginkgo.When("versions dont match", func() {
+			testCases := []table.TableEntry{
+				table.Entry(
+					"Regular kernel mismatch",
+					map[string]upgrade.NodeVersion{
+						defaultKernelFullVersionArch: upgrade.NodeVersion{
+							OSVersion:      "8.1",
+							ClusterVersion: defaultClusterVersion,
+						},
+					},
+					"OSVersion mismatch NFD: 8.1 vs. DTK: 8.4",
+				),
+				table.Entry(
+					"RT kernel mismatch",
+					map[string]upgrade.NodeVersion{
+						defaultRTKernelFullVersionArch: upgrade.NodeVersion{
+							OSVersion:      "8.2",
+							ClusterVersion: defaultClusterVersion,
+						},
+					},
+					"OSVersion mismatch NFD: 8.2 vs. DTK: 8.4",
+				),
+			}
+			table.DescribeTable("test table", func(input map[string]upgrade.NodeVersion, expected string) {
+				_, err := upgrade.UpdateInfo(input, defaultDTKInput, defaultImageURLInput)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).To(gomega.Equal(expected))
+			}, testCases...)
+		})
+	})
+})
+
+func TestPkgUpgrade(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "pkg/upgrade Unit tests")
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,110 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/internal/global"
+	"github.com/onsi/ginkgo/types"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+
+A description function can be passed to Entry in place of the description. The function is then fed with the entry parameters to generate the description of the It corresponding to that particular Entry.
+
+For example:
+
+	describe := func(desc string) func(int, int, bool) string {
+		return func(x, y int, expected bool) string {
+			return fmt.Sprintf("%s x=%d y=%d expected:%t", desc, x, y, expected)
+		}
+	}
+
+	DescribeTable("a simple table",
+		func(x int, y int, expected bool) {
+			Ω(x > y).Should(Equal(expected))
+		},
+		Entry(describe("x > y"), 1, 0, true),
+		Entry(describe("x == y"), 0, 0, false),
+		Entry(describe("x < y"), 0, 1, false),
+	)
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypeNone)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypeFocused)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypePending)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypePending)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, flag types.FlagType) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	global.Suite.PushContainerNode(
+		description,
+		func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		},
+		flag,
+		codelocation.New(2),
+	)
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,129 @@
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/internal/global"
+	"github.com/onsi/ginkgo/types"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description  interface{}
+	Parameters   []interface{}
+	Pending      bool
+	Focused      bool
+	codeLocation types.CodeLocation
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	var description string
+	descriptionValue := reflect.ValueOf(t.Description)
+	switch descriptionValue.Kind() {
+	case reflect.String:
+		description = descriptionValue.String()
+	case reflect.Func:
+		values := castParameters(descriptionValue, t.Parameters)
+		res := descriptionValue.Call(values)
+		if len(res) != 1 {
+			panic(fmt.Sprintf("The describe function should return only a value, returned %d", len(res)))
+		}
+		if res[0].Kind() != reflect.String {
+			panic(fmt.Sprintf("The describe function should return a string, returned %#v", res[0]))
+		}
+		description = res[0].String()
+	default:
+		panic(fmt.Sprintf("Description can either be a string or a function, got %#v", descriptionValue))
+	}
+
+	if t.Pending {
+		global.Suite.PushItNode(description, func() {}, types.FlagTypePending, t.codeLocation, 0)
+		return
+	}
+
+	values := castParameters(itBody, t.Parameters)
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		global.Suite.PushItNode(description, body, types.FlagTypeFocused, t.codeLocation, global.DefaultTimeout)
+	} else {
+		global.Suite.PushItNode(description, body, types.FlagTypeNone, t.codeLocation, global.DefaultTimeout)
+	}
+}
+
+func castParameters(function reflect.Value, parameters []interface{}) []reflect.Value {
+	res := make([]reflect.Value, len(parameters))
+	funcType := function.Type()
+	for i, param := range parameters {
+		if param == nil {
+			inType := funcType.In(i)
+			res[i] = reflect.Zero(inType)
+		} else {
+			res[i] = reflect.ValueOf(param)
+		}
+	}
+	return res
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      false,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      false,
+		Focused:      true,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      true,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      true,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}


### PR DESCRIPTION
When using RT kernels the DTK image is not set, rendering broken BuildConfigs. This was due to a bug when retrieving cluster info after matching nodes and DTK metadata.