### PR TITLE
Remove dangling special resources after undeploying in CI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -65,14 +65,20 @@ jobs:
         openshift_password: ${{ secrets.OPENSHIFT_PASSWORD }}
         insecure_skip_tls_verify: true
         namespace: default
+    - name: Forced delete all SpecialResources from previous runs
+      run: |
+          for i in `oc get specialresources.sro.openshift.io -o jsonpath='{.items[*].metadata.name}'`;
+            do oc patch specialresources.sro.openshift.io $i -p '{"metadata":{"finalizers":[]}}' --type=merge;
+            oc delete specialresources.sro.openshift.io $i --ignore-not-found
+          done
     - run: make deploy
-      env:
-        TAG: master
-      continue-on-error: true
-    - run: make undeploy
-    - run: make go-deploy-manifests
       env:
         TAG: pr-${{ steps.short-sha.outputs.sha }}
     - run: make test-e2e
+      id: teste2e
     - run: oc logs deployment/special-resource-controller-manager -n openshift-special-resource-operator -c manager
-    - run: make go-undeploy-manifests
+      if: steps.teste2e.outcome == 'failure'
+    - run: make undeploy
+      if: always()
+      env:
+        TAG: pr-${{ steps.short-sha.outputs.sha }}


### PR DESCRIPTION
Everytime a CI e2e test loop runs there is some resource spillover leaking to the next iteration. The last step of the action is to run `make go-undeploy-manifests`, which eliminates everything under the `manifests` directory. This removes the whole operator except for the SpecialResource CRs. Since those SRs have finalizers that are unable to be fulfilled, because the manager is not there anymore, they remain with a `deletionTimestamp` until reconciled.

When the next build comes, the `make deploy` will complain with this message:
`Error from server (MethodNotAllowed): error when creating "STDIN": create not allowed while custom resource definition is terminating`
Which is caused by the situation described above. After this, we trigger a `make undeploy`, which might be fast enough to not reconcile the deleted SRs from the previous run, getting us into a deadlock because those SRs can not be deleted without finalizing them.

This PR tries to overcome the situation by removing the finalizers on any dangling SRs and delete them right after the `make go-undeploy-manifests` target so that the next build comes to a clean cluster.