### PR TITLE
Fix deploy target and e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -77,7 +77,7 @@ jobs:
     - run: make test-e2e
       id: teste2e
     - run: oc logs deployment/special-resource-controller-manager -n openshift-special-resource-operator -c manager
-      if: steps.teste2e.outcome == 'failure'
+      if: always() && steps.teste2e.outcome == 'failure'
     - run: make undeploy
       if: always()
       env:

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,6 @@ SHELL             = /usr/bin/env bash -o pipefail
 # GENERATED all: manager
 all: $(SPECIALRESOURCE)
 
-namespace: patch manifests kustomize
-	$(KUSTOMIZE) build config/namespace | kubectl apply -f -
-
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
@@ -101,7 +98,8 @@ install: manifests kustomize  ## Install CRDs into the K8s cluster specified in 
 uninstall: manifests kustomize  ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
-deploy: namespace ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+deploy: manifests kustomize configure ## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+	$(KUSTOMIZE) build config/namespace | kubectl apply -f -
 	$(KUSTOMIZE) build config/default$(SUFFIX) | kubectl apply -f -
 	$(shell sleep 5)
 	$(KUSTOMIZE) build config/cr | kubectl apply -f -


### PR DESCRIPTION
Fix `deploy` target in Makefile to set the image according to the `$TAG` variable.

Fix e2e workflow to read logs only if the previous step (the actual test) fails. This was flawed because as soon as a step fails all the following ones are cancelled unless they have a special `if` clause. If this clause does not evaluate status (either `success()` or `failure()`) or executes `always()`, it is taken as a `success()` regardless of the expression it contains. As the previous step is failing, `success()` evaluates to false and logs are not retrieved.