### PR TITLE
Fixing the getRuntimeInfo function

### DIFF
--- a/Dockerfile.special-resource-operator-build
+++ b/Dockerfile.special-resource-operator-build
@@ -10,7 +10,7 @@ RUN yum install -y which
 RUN yum install -y podman docker
 RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /tmp/kubectl
 RUN install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
+RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
 RUN GO111MODULE=on go install golang.stackrox.io/kube-linter/cmd/kube-linter@latest
 RUN curl -L --retry 5 "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.3.0/kustomize_v4.3.0_linux_amd64.tar.gz" | \
     tar -zx -C /usr/bin

--- a/controllers/runtime.go
+++ b/controllers/runtime.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift-psap/special-resource-operator/pkg/kernel"
 	"github.com/openshift-psap/special-resource-operator/pkg/proxy"
 	"github.com/openshift-psap/special-resource-operator/pkg/upgrade"
+	"github.com/openshift-psap/special-resource-operator/pkg/warn"
 	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -125,9 +126,7 @@ func getRuntimeInformation(r *SpecialResourceReconciler) error {
 	}
 
 	RunInfo.PushSecretName, err = retryGetPushSecretName(r)
-	if err != nil {
-		return fmt.Errorf("failed to get push secret name: %w", err)
-	}
+	warn.OnError(err)
 
 	RunInfo.OSImageURL, err = cluster.OSImageURL()
 	if err != nil {


### PR DESCRIPTION
Secret for build-config in a CR's specific namespace might not
present, so the function should not fail in that case. This PR
removes the exit and adds a log