### PR TITLE
Upgrade golangci-lint version to 1.43

### DIFF
--- a/Makefile.helper.mk
+++ b/Makefile.helper.mk
@@ -54,7 +54,7 @@ kube-linter:
 # Download golangci-lint locally if necessary
 GOLANGCILINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
-	$(call go-get-tool,$(GOLANGCILINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.33.0)
+	$(call go-get-tool,$(GOLANGCILINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0)
 
 # Additional bundle options for ART
 DEFAULT_CHANNEL="4.9"


### PR DESCRIPTION
This PR bumps version of golangci-lint from 1.33 (Nov 2020) to 1.43 (Nov 2021).
To fetch new binary, old one must be removed from `./bin/golangci-lint`.