### PR TITLE
MGMT-8421: add nodes metrics for DaemonSet and Deployment

### DIFF
--- a/pkg/lifecycle/lifecycle_test.go
+++ b/pkg/lifecycle/lifecycle_test.go
@@ -76,7 +76,7 @@ var _ = Describe("GetPodFromDaemonSet", func() {
 		gomock.InOrder(
 			mockClient.EXPECT().
 				Get(context.TODO(), nsn, unstructuredMatcher).
-				Do(func(ctx context.Context, _ types.NamespacedName, uo *unstructured.Unstructured) {
+				Do(func(ctx context.Context, key types.NamespacedName, uo *unstructured.Unstructured) {
 					m := make(map[string]interface{}, len(labels))
 
 					for k, v := range labels {
@@ -85,6 +85,7 @@ var _ = Describe("GetPodFromDaemonSet", func() {
 
 					err := unstructured.SetNestedMap(uo.Object, m, "spec", "selector", "matchLabels")
 					Expect(err).NotTo(HaveOccurred())
+					uo.SetNamespace(key.Namespace)
 				}),
 			mockClient.EXPECT().
 				List(context.TODO(), unstructuredListMatcher, optNs, optLabels).
@@ -123,10 +124,11 @@ var _ = Describe("UpdateDaemonSetPods", func() {
 			Name:      cmName,
 		}
 
+		// [TODO] - update the mocks, once storage package becomes typed interface with mock
 		gomock.InOrder(
 			mockClient.EXPECT().
 				Get(context.TODO(), nsn, unstructuredMatcher).
-				Do(func(_ context.Context, _ types.NamespacedName, uo *unstructured.Unstructured) {
+				Do(func(_ context.Context, key types.NamespacedName, uo *unstructured.Unstructured) {
 					m := make(map[string]interface{}, len(labels))
 
 					for k, v := range labels {
@@ -135,6 +137,7 @@ var _ = Describe("UpdateDaemonSetPods", func() {
 
 					err := unstructured.SetNestedMap(uo.Object, m, "spec", "selector", "matchLabels")
 					Expect(err).NotTo(HaveOccurred())
+					uo.SetNamespace(key.Namespace)
 				}),
 			mockClient.EXPECT().
 				List(context.TODO(), unstructuredListMatcher, optNs, optLabels).

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -14,12 +14,14 @@ const (
 	specialResourceCreateValue = 1
 	completedStatesValue       = 2
 	completedKindValue         = 2
+	usedNodesValue             = 1
 
-	sr        = "simple-kmod"
-	state     = "templates/0000-buildconfig.yaml"
-	kind      = "BuildConfig"
-	name      = "simple-kmod-driver-build"
-	namespace = "openshift-special-resource-operator"
+	sr         = "simple-kmod"
+	state      = "templates/0000-buildconfig.yaml"
+	kind       = "BuildConfig"
+	name       = "simple-kmod-driver-build"
+	namespace  = "openshift-special-resource-operator"
+	nodes_list = "node1,node2,node3"
 )
 
 func TestMetrics(t *testing.T) {
@@ -41,6 +43,7 @@ var _ = Describe("Metrics", func() {
 	m.SetSpecialResourcesCreated(specialResourceCreateValue)
 	m.SetCompletedState(sr, state, completedStatesValue)
 	m.SetCompletedKind(sr, kind, name, namespace, completedKindValue)
+	m.SetUsedNodes(sr, kind, name, namespace, nodes_list)
 
 	It("correctly passes calls to the collectors", func() {
 		expected := []struct {
@@ -50,6 +53,7 @@ var _ = Describe("Metrics", func() {
 			{createdSpecialResourcesQuery, specialResourceCreateValue},
 			{completedStatesQuery, completedStatesValue},
 			{completedKindQuery, completedKindValue},
+			{usedNodesQuery, usedNodesValue},
 		}
 
 		data, err := metrics.Registry.Gather()


### PR DESCRIPTION
This PR add a mmetrics that contains CR, Kind, Name and Namespace
labels , alond with a label that contains the names of the nodes that
the pods of the DaemonSet/Deployment are running on. The metrics are set
only once the DaemonsSet/deployment are fully available