### PR TITLE
Build manager using makefile within dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,25 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 # RUN go mod download
 
+COPY hack/ hack/
+COPY Makefile.specialresource.mk Makefile.specialresource.mk
+COPY Makefile.helm.mk Makefile.helm.mk
+COPY Makefile.helper.mk Makefile.helper.mk
+COPY Makefile Makefile
+COPY scripts/ scripts/
+
 # Copy the go source
+COPY vendor/ vendor/
+COPY .patches/ .patches/
 COPY main.go main.go
 COPY api/ api/
 COPY cmd/ cmd/
 COPY controllers/ controllers/
-
 COPY pkg/ pkg/
-COPY vendor/ vendor/
 
-# Build
-RUN CGO_ENABLED=0 GO111MODULE=on go build -mod=vendor -a -o manager main.go
+RUN ["apt", "update"]
+RUN ["apt", "install", "-y", "patch"]
+RUN ["make", "manager"]
 
 FROM debian:bullseye-slim
 
@@ -31,7 +39,6 @@ WORKDIR /
 COPY --from=builder /workspace/manager .
 
 COPY charts/ /charts/
-COPY manifests /manifests
 
 RUN useradd  -r -u 499 nonroot
 RUN getent group nonroot || groupadd -o -g 499 nonroot

--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,13 @@ unit-test: ## Run unit-tests.
 ##@ Build
 
 manager: patch generate ## Build manager binary.
-	go build -mod=vendor -o /tmp/bin/manager main.go
+	go build -o manager main.go
 
 run: manifests generate ## Run against the configured Kubernetes cluster in ~/.kube/config
 	go run -mod=vendor ./main.go
 
-local-image-build: patch helm-lint helm-repo-index generate manifests-gen ## Build container image with the manager.
-	$(CONTAINER_COMMAND) build -t $(IMG) --no-cache .
+local-image-build: helm-lint helm-repo-index generate manifests-gen ## Build container image with the manager.
+	$(CONTAINER_COMMAND) build -t $(IMG) .
 
 local-image-push: ## Push docker image with the manager.
 	$(CONTAINER_COMMAND) push $(IMG)


### PR DESCRIPTION
Build the operator within the build stage in dockerfile. Does not require installing additional software and/or running pre-steps prior to building the container.