### PR TITLE
MGMT-8390: exclude helm charts built artifacts from git management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Temporary Build Files
 build/_output
 build/_test
+build/charts
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV HELM_PLUGINS /opt/helm-plugins
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/helm-plugins ${HELM_PLUGINS}
 
-COPY charts/ /charts/
+COPY build/charts/ /charts/
 
 RUN useradd  -r -u 499 nonroot
 RUN getent group nonroot || groupadd -o -g 499 nonroot

--- a/Makefile.helm.mk
+++ b/Makefile.helm.mk
@@ -1,22 +1,31 @@
-HELM_REPOS = $(shell ls -d charts/*/)
+HELM_CHARTS_DIR = charts
+HELM_BUILD_ROOT_DIR = build
+HELM_BUILD_DIR = $(HELM_BUILD_ROOT_DIR)/$(HELM_CHARTS_DIR)
+HELM_REPOS = $(shell ls -d $(HELM_BUILD_DIR)/*/)
 
 
-helm-lint: helm
+helm-lint: helm helm-copy-charts
 	echo $(HELM_REPOS)
 	@for repo in $(HELM_REPOS); do                          \
 		cd $$repo;                              \
 		helm lint -f ../global-values.yaml `ls -d */`; \
-		cd ../..;                                      \
+		cd ../../..;                                    \
 	done
 
 helm-repo-index: helm-lint
-	@for repo in $(HELM_REPOS); do                          \
+	@for repo in $(HELM_REPOS); do                  \
 		cd $$repo;                              \
-		helm package `ls -d */`;                      \
-		helm repo index . --url=file:///$$repo; \
-		cd ../..;                                      \
+		helm package `ls -d */`;                \
+		file_url=`echo $$repo |sed 's/$(HELM_BUILD_ROOT_DIR)\///g'`;   \
+		helm repo index . --url=file:///$$file_url; \
+		cd ../../..;	                        \
 	done
 
+
+helm-copy-charts:
+	rm -rf $(HELM_BUILD_DIR)
+	mkdir -p $(HELM_BUILD_DIR)
+	cp -r $(HELM_CHARTS_DIR)/* $(HELM_BUILD_DIR)
 
 
 helm:

--- a/Makefile.specialresource.mk
+++ b/Makefile.specialresource.mk
@@ -6,11 +6,11 @@ SR ?= $(SPECIALRESOURCE)
 TMP := $(shell mktemp -d)
 
 $(SPECIALRESOURCE):
-	kubectl apply -f charts/$(REPO)/$(SR)-$(VERSION)/$(SR).yaml
+	kubectl apply -f build/charts/$(REPO)/$(SR)-$(VERSION)/$(SR).yaml
 
 
 chart: helm-repo-index
-	@cp charts/$(REPO)/$(SR)-$(VERSION).tgz $(TMP)/.
+	@cp build/charts/$(REPO)/$(SR)-$(VERSION).tgz $(TMP)/.
 	@helm repo index $(TMP) --url=cm://$(NS)/$(SR)-chart
 	@kubectl create ns $(NS) --dry-run=client -o yaml | kubectl apply -f -
 	@kubectl create cm $(SR)-chart --from-file=$(TMP)/index.yaml --from-file=$(TMP)/$(SR)-$(VERSION).tgz --dry-run=client -o yaml -n $(NS) | kubectl apply -f -


### PR DESCRIPTION
Currently all the helm operation on the chats (helm repo, helm lint,
helm package) are executed on the charts directory (under git control).
It means that eveyr image build, or other command that involves helm operations
contaminates code under git control ( very inconvient). This PR moves all
the chart to a new directory (not under git control), and all the rest of the helm action
are executed there.