### PR TITLE
Adding debug info to k8s-e2e GH action.

### DIFF
--- a/.github/workflows/k8s-e2e.yaml
+++ b/.github/workflows/k8s-e2e.yaml
@@ -77,6 +77,10 @@ jobs:
       env:
         TAG: pr-${{ steps.short-sha.outputs.sha }}
         PLATFORM: k8s
+    - run: kubectl describe deploy/special-resource-controller-manager -n openshift-special-resource-operator
+    - run: kubectl logs deploy/special-resource-controller-manager -n openshift-special-resource-operator -c manager
+    - run: kubectl describe pod/$(kubectl get pods -n openshift-special-resource-operator | tail -n1 | cut -d" " -f1) -n openshift-special-resource-operator
+    - run: kubectl logs pod/$(kubectl get pods -n openshift-special-resource-operator | tail -n1 | cut -d" " -f1) -n openshift-special-resource-operator -c manager
     - run: kubectl rollout status deployment -n openshift-special-resource-operator special-resource-controller-manager --timeout=300s
 
     - run: kubectl apply -f  charts/example/centos-simple-kmod-0.0.1/centos-simple-kmod.yaml


### PR DESCRIPTION
When the deployment if failing, we don't have any way to see what when
wrong.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>