### PR TITLE
MGMT-8720: support ARM DTK kernel versions

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -121,8 +121,11 @@ func (ci *clusterInfo) updateInfo(info map[string]NodeVersion, dtk registry.Driv
 	osDTK := dtk.OSVersion
 	// Assumes all nodes have the same architecture
 	runningArch := runtime.GOARCH
-	if runningArch == "amd64" {
+	switch runningArch {
+	case "amd64":
 		runningArch = "x86_64"
+	case "arm64":
+		runningArch = "aarch64"
 	}
 	if !strings.Contains(dtk.KernelFullVersion, runningArch) {
 		dtk.KernelFullVersion = dtk.KernelFullVersion + "." + runningArch


### PR DESCRIPTION
For ARM compilation, GOARCH can be define as arm64 by the golang, while the kernel version
contains the "aarch64" definition. We need to translate the runtime definition to the one
defined by the OCP by the OCP build , in order to avoid the case where DTK image is not set,
since the node kernel version is not matching the DTK kernel version