### PR TITLE
MGMT-8725: add debug info for Build error case

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -121,6 +121,8 @@ func (ci *clusterInfo) updateInfo(info map[string]NodeVersion, dtk registry.Driv
 	osDTK := dtk.OSVersion
 	// Assumes all nodes have the same architecture
 	runningArch := runtime.GOARCH
+	ci.log.Info("Runtime GOARCH is:", "runningArch", runningArch)
+	ci.log.Info("dtk.KernelFullVersion is:", "kernelVersion", dtk.KernelFullVersion)
 	switch runningArch {
 	case "amd64":
 		runningArch = "x86_64"


### PR DESCRIPTION
Adding debug info for future debugging of Build error in case
Build enters error state due to malformated Dockerfile