### PR TITLE
MGMT-8835: remove clients.Interface from controller package

### DIFF
--- a/controllers/runtime.go
+++ b/controllers/runtime.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	srov1beta1 "github.com/openshift-psap/special-resource-operator/api/v1beta1"
-	"github.com/openshift-psap/special-resource-operator/pkg/clients"
 	"github.com/openshift-psap/special-resource-operator/pkg/proxy"
 	"github.com/openshift-psap/special-resource-operator/pkg/upgrade"
 	"github.com/openshift-psap/special-resource-operator/pkg/utils"
@@ -106,7 +105,7 @@ func getRuntimeInformation(ctx context.Context, r *SpecialResourceReconciler) er
 
 	// Only want to initialize the platform once.
 	if RunInfo.Platform == "" {
-		RunInfo.Platform, err = clients.Interface.GetPlatform()
+		RunInfo.Platform, err = r.KubeClient.GetPlatform()
 		if err != nil {
 			return fmt.Errorf("failed to determine platform: %v", err)
 		}
@@ -171,7 +170,7 @@ func getPushSecretName(ctx context.Context, r *SpecialResourceReconciler) (strin
 	opts := []client.ListOption{
 		client.InNamespace(r.specialresource.Spec.Namespace),
 	}
-	err := clients.Interface.List(ctx, secrets, opts...)
+	err := r.KubeClient.List(ctx, secrets, opts...)
 	if err != nil {
 		return "", errors.Wrap(err, "Client cannot get SecretList")
 	}

--- a/controllers/scale_up_down.go
+++ b/controllers/scale_up_down.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/openshift-psap/special-resource-operator/pkg/cache"
-	"github.com/openshift-psap/special-resource-operator/pkg/clients"
 	"github.com/openshift-psap/special-resource-operator/pkg/state"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -29,7 +28,7 @@ func (r *SpecialResourceReconciler) labelNodesAccordingToState(ctx context.Conte
 
 		updated.SetLabels(labels)
 
-		if err = clients.Interface.Update(ctx, updated); err != nil {
+		if err = r.KubeClient.Update(ctx, updated); err != nil {
 			if apierrors.IsForbidden(err) {
 				return fmt.Errorf("forbidden - check Role, ClusterRole and Bindings: %w", err)
 			}

--- a/controllers/specialresource_controller.go
+++ b/controllers/specialresource_controller.go
@@ -77,6 +77,7 @@ type SpecialResourceReconciler struct {
 	Storage     storage.Storage
 	KernelData  kernel.KernelData
 	ProxyAPI    proxy.ProxyAPI
+	KubeClient  clients.ClientsInterface
 
 	specialresource srov1beta1.SpecialResource
 	parent          srov1beta1.SpecialResource
@@ -131,7 +132,7 @@ func (r *SpecialResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 func (r *SpecialResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	log = r.Log.WithName(utils.Print("setup", utils.Brown))
 
-	platform, err := clients.Interface.GetPlatform()
+	platform, err := r.KubeClient.GetPlatform()
 	if err != nil {
 		return err
 	}

--- a/pkg/clients/clients.go
+++ b/pkg/clients/clients.go
@@ -31,8 +31,7 @@ const (
 )
 
 var (
-	log       = zap.New(zap.UseDevMode(true)).WithName(utils.Print("clients", utils.Brown))
-	Interface ClientsInterface
+	log = zap.New(zap.UseDevMode(true)).WithName(utils.Print("clients", utils.Brown))
 	// TODO need to remove this global variable
 	Namespace string
 )

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -33,13 +33,10 @@ func TestStorage(t *testing.T) {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockClient = clients.NewMockClientsInterface(ctrl)
-
-		clients.Interface = mockClient
 	})
 
 	AfterEach(func() {
 		ctrl.Finish()
-		clients.Interface = nil
 	})
 
 	RunSpecs(t, "Storage Suite")


### PR DESCRIPTION
Moves the code of the controlller package to use an internal
field of the Reconciler instead of the global clients.Interface
variable.
Complete removal of the clients.Interface from the code