### PR TITLE
Fix poll pkg bug for buildconfig resources

### DIFF
--- a/pkg/poll/poll.go
+++ b/pkg/poll/poll.go
@@ -427,14 +427,29 @@ func (p *pollActions) forBuild(ctx context.Context, obj *unstructured.Unstructur
 		return errors.Wrap(err, "Could not get BuildList")
 	}
 
-	for _, build := range builds.Items {
-		callback := makeStatusCallback("Complete", "status", "phase")
-		if err := p.forResourceFullAvailability(ctx, &build, callback); err != nil {
+	var build *unstructured.Unstructured
+	for _, b := range builds.Items {
+		slice, found, err := unstructured.NestedSlice(b.Object, "metadata", "ownerReferences")
+		if err != nil {
 			return err
 		}
+		found = false
+		for _, element := range slice {
+			if name, ok := element.(map[string]interface{})["name"]; ok && name == obj.GetName() {
+				found = true
+				break
+			}
+		}
+		if found {
+			build = &b
+			break
+		}
 	}
-
-	return nil
+	if build == nil {
+		return errors.New("Build object not yet available")
+	}
+	callback := makeStatusCallback("Complete", "status", "phase")
+	return p.forResourceFullAvailability(ctx, build, callback)
 }
 
 func (p *pollActions) forResourceFullAvailability(ctx context.Context, obj *unstructured.Unstructured, callback statusCallback) error {

--- a/pkg/poll/poll.go
+++ b/pkg/poll/poll.go
@@ -429,19 +429,17 @@ func (p *pollActions) forBuild(ctx context.Context, obj *unstructured.Unstructur
 
 	var build *unstructured.Unstructured
 	for _, b := range builds.Items {
-		slice, found, err := unstructured.NestedSlice(b.Object, "metadata", "ownerReferences")
+		slice, _, err := unstructured.NestedSlice(b.Object, "metadata", "ownerReferences")
 		if err != nil {
 			return err
 		}
-		found = false
 		for _, element := range slice {
 			if name, ok := element.(map[string]interface{})["name"]; ok && name == obj.GetName() {
-				found = true
+				build = &b
 				break
 			}
 		}
-		if found {
-			build = &b
+		if build != nil {
 			break
 		}
 	}

--- a/pkg/poll/poll_test.go
+++ b/pkg/poll/poll_test.go
@@ -259,60 +259,56 @@ var _ = Context("Waiting for resource", func() {
 })
 
 var _ = Context("Waiting for Build", func() {
-	When("resource is not created yet", func() {
-		It("should fail", func() {
-			// forResourceAvailability
-			mockClientsInterface.EXPECT().Get(Any(), Any(), Any()).Return(nil)
-			// forBuild
-			mockClientsInterface.EXPECT().List(Any(), Any(), Any()).Return(nil)
-			Expect(pa.ForResource(context.Background(), prepareUnstructured("BuildConfig", "build-name", namespace))).To(Not(Succeed()))
-		})
+	It("should fail when resource is not created yet", func() {
+		// forResourceAvailability
+		mockClientsInterface.EXPECT().Get(Any(), Any(), Any()).Return(nil)
+		// forBuild
+		mockClientsInterface.EXPECT().List(Any(), Any(), Any()).Return(nil)
+		Expect(pa.ForResource(context.Background(), prepareUnstructured("BuildConfig", "build-name", namespace))).To(Not(Succeed()))
 	})
-	When("resource is created", func() {
-		It("belongs to my BuildConfig and is finished", func() {
-			// forResourceAvailability
-			mockClientsInterface.EXPECT().Get(Any(), Any(), Any()).Return(nil)
-			// forBuild
-			mockClientsInterface.EXPECT().
-				List(Any(), Any(), Any()).
-				DoAndReturn(func(_ context.Context, obj client.ObjectList, _ ...client.ListOption) error {
-					build := prepareUnstructured("Build", "build-name-1", namespace)
-					unstructured.SetNestedSlice(build.Object, []interface{}{map[string]interface{}{
-						"name": "build-name",
-					}}, "metadata", "ownerReferences")
-					u := obj.(*unstructured.UnstructuredList)
-					u.Items = append(u.Items, *build)
-					return nil
-				})
-			// forResourceFullAvailability
-			mockClientsInterface.EXPECT().Get(Any(), Any(), Any()).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, o client.Object) error {
-					u := o.(*unstructured.Unstructured)
-					Expect(unstructured.SetNestedField(u.Object, "Complete", "status", "phase")).To(Succeed())
-					return nil
-				})
+	It("resource is created and belongs to my BuildConfig and is finished", func() {
+		// forResourceAvailability
+		mockClientsInterface.EXPECT().Get(Any(), Any(), Any()).Return(nil)
+		// forBuild
+		mockClientsInterface.EXPECT().
+			List(Any(), Any(), Any()).
+			DoAndReturn(func(_ context.Context, obj client.ObjectList, _ ...client.ListOption) error {
+				build := prepareUnstructured("Build", "build-name-1", namespace)
+				Expect(unstructured.SetNestedSlice(build.Object, []interface{}{map[string]interface{}{
+					"name": "build-name",
+				}}, "metadata", "ownerReferences")).To(Succeed())
+				u := obj.(*unstructured.UnstructuredList)
+				u.Items = append(u.Items, *build)
+				return nil
+			})
+		// forResourceFullAvailability
+		mockClientsInterface.EXPECT().Get(Any(), Any(), Any()).
+			DoAndReturn(func(_ context.Context, _ client.ObjectKey, o client.Object) error {
+				u := o.(*unstructured.Unstructured)
+				Expect(unstructured.SetNestedField(u.Object, "Complete", "status", "phase")).To(Succeed())
+				return nil
+			})
 
-			Expect(pa.ForResource(context.Background(), prepareUnstructured("BuildConfig", "build-name", namespace))).To(Succeed())
-		})
-		It("does not belong to my BuildConfig", func() {
-			// forResourceAvailability
-			mockClientsInterface.EXPECT().Get(Any(), Any(), Any()).Return(nil)
+		Expect(pa.ForResource(context.Background(), prepareUnstructured("BuildConfig", "build-name", namespace))).To(Succeed())
+	})
+	It("resource is created and does not belong to my BuildConfig", func() {
+		// forResourceAvailability
+		mockClientsInterface.EXPECT().Get(Any(), Any(), Any()).Return(nil)
 
-			// forBuild
-			mockClientsInterface.EXPECT().
-				List(Any(), Any(), Any()).
-				DoAndReturn(func(_ context.Context, obj client.ObjectList, _ ...client.ListOption) error {
-					build := prepareUnstructured("Build", "build-name-1", namespace)
-					unstructured.SetNestedSlice(build.Object, []interface{}{map[string]interface{}{
-						"name": "other-build-name",
-					}}, "metadata", "ownerReferences")
-					u := obj.(*unstructured.UnstructuredList)
-					u.Items = append(u.Items, *build)
-					return nil
-				})
+		// forBuild
+		mockClientsInterface.EXPECT().
+			List(Any(), Any(), Any()).
+			DoAndReturn(func(_ context.Context, obj client.ObjectList, _ ...client.ListOption) error {
+				build := prepareUnstructured("Build", "build-name-1", namespace)
+				Expect(unstructured.SetNestedSlice(build.Object, []interface{}{map[string]interface{}{
+					"name": "other-build-name",
+				}}, "metadata", "ownerReferences")).To(Succeed())
+				u := obj.(*unstructured.UnstructuredList)
+				u.Items = append(u.Items, *build)
+				return nil
+			})
 
-			Expect(pa.ForResource(context.Background(), prepareUnstructured("BuildConfig", "build-name", namespace))).To(Not(Succeed()))
-		})
+		Expect(pa.ForResource(context.Background(), prepareUnstructured("BuildConfig", "build-name", namespace))).To(Not(Succeed()))
 	})
 })
 


### PR DESCRIPTION
When there is more than one `buildconfig` resource in the same namespace, poll package queries and waits for all builds, ignoring the build owner, and in turn, possibly waiting on not owned resources. Also fixes waiting for not yet created build pods.