### PR TITLE
Remove kernel affinity from simple-kmod BuildConfig

### DIFF
--- a/charts/example/simple-kmod-0.0.1/templates/0000-buildconfig.yaml
+++ b/charts/example/simple-kmod-0.0.1/templates/0000-buildconfig.yaml
@@ -15,7 +15,6 @@ metadata:
   annotations:
     specialresource.openshift.io/wait: "true"
     specialresource.openshift.io/driver-container-vendor: simple-kmod
-    specialresource.openshift.io/kernel-affine: "true"
 spec:
   nodeSelector:
     node-role.kubernetes.io/worker: ""
@@ -31,10 +30,6 @@ spec:
   strategy:
     dockerStrategy:
       dockerfilePath: Dockerfile.SRO
-#      from:
-#        kind: "ImageStreamTag"
-#        name: "driver-container-base:v{{.Values.kernelFullVersion}}"
-#        namespace: "driver-container-base"
       buildArgs:
         - name: "IMAGE"
           value: {{ .Values.driverToolkitImage  }}


### PR DESCRIPTION
Build config resources dont need affinity since they dont require anything from the host, like driver containers. These are cross-compile containers, therefore we dont care if they run in some other kernel because the content remains the same.
Removing this line as it may cause confusion because of this chart being an example/base for others.