### PR TITLE
MGMT-9106: adjust SRO upgrade for kuberenetes

### DIFF
--- a/controllers/resources.go
+++ b/controllers/resources.go
@@ -192,14 +192,12 @@ func ReconcileChartStates(ctx context.Context, r *SpecialResourceReconciler) err
 			RunInfo.OperatingSystemDecimal = version.OSVersion
 			RunInfo.OperatingSystemMajorMinor = version.OSMajorMinor
 			RunInfo.OperatingSystemMajor = version.OSMajor
-			RunInfo.DriverToolkitImage = version.DriverToolkit.ImageURL
 
 			if kernelAffine {
 				log.Info("KernelAffine: ClusterUpgradeInfo",
 					"kernel", RunInfo.KernelFullVersion,
 					"os", RunInfo.OperatingSystemDecimal,
-					"cluster", RunInfo.ClusterVersionMajorMinor,
-					"driverToolkitImage", RunInfo.DriverToolkitImage)
+					"cluster", RunInfo.ClusterVersionMajorMinor)
 			}
 
 			var err error
@@ -235,9 +233,6 @@ func ReconcileChartStates(ctx context.Context, r *SpecialResourceReconciler) err
 				RunInfo.KernelFullVersion,
 				RunInfo.OperatingSystemDecimal,
 				r.specialresource.Spec.Debug)
-			//if err != nil {
-			//	return err
-			//}
 
 			replicas += 1
 

--- a/controllers/runtime.go
+++ b/controllers/runtime.go
@@ -34,7 +34,6 @@ type RuntimeInformation struct {
 	OperatingSystemDecimal    string                         `json:"operatingSystemDecimal"`
 	KernelFullVersion         string                         `json:"kernelFullVersion"`
 	KernelPatchVersion        string                         `json:"kernelPatchVersion"`
-	DriverToolkitImage        string                         `json:"driverToolkitImage"`
 	Platform                  string                         `json:"platform"`
 	ClusterVersion            string                         `json:"clusterVersion"`
 	ClusterVersionMajorMinor  string                         `json:"clusterVersionMajorMinor"`
@@ -53,7 +52,6 @@ var RunInfo = RuntimeInformation{
 	OperatingSystemDecimal:    "",
 	KernelFullVersion:         "",
 	KernelPatchVersion:        "",
-	DriverToolkitImage:        "",
 	Platform:                  "",
 	ClusterVersion:            "",
 	ClusterVersionMajorMinor:  "",
@@ -71,7 +69,6 @@ func logRuntimeInformation() {
 	log.Info("Runtime Information", "OperatingSystemDecimal", RunInfo.OperatingSystemDecimal)
 	log.Info("Runtime Information", "KernelFullVersion", RunInfo.KernelFullVersion)
 	log.Info("Runtime Information", "KernelPatchVersion", RunInfo.KernelPatchVersion)
-	log.Info("Runtime Information", "DriverToolkitImage", RunInfo.DriverToolkitImage)
 	log.Info("Runtime Information", "Platform", RunInfo.Platform)
 	log.Info("Runtime Information", "ClusterVersion", RunInfo.ClusterVersion)
 	log.Info("Runtime Information", "ClusterVersionMajorMinor", RunInfo.ClusterVersionMajorMinor)

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -3,13 +3,8 @@ package upgrade
 import (
 	"context"
 	"fmt"
-	"runtime"
-	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
-
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/openshift-psap/special-resource-operator/pkg/cluster"
 	"github.com/openshift-psap/special-resource-operator/pkg/registry"
@@ -19,9 +14,8 @@ import (
 )
 
 const (
-	labelKernelVersionFull    = "feature.node.kubernetes.io/kernel-version.full"
-	labelOSReleaseVersionID   = "feature.node.kubernetes.io/system-os_release.VERSION_ID"
-	labelOSReleaseRHELVersion = "feature.node.kubernetes.io/system-os_release.RHEL_VERSION"
+	labelKernelVersionFull  = "feature.node.kubernetes.io/kernel-version.full"
+	labelOSReleaseVersionID = "feature.node.kubernetes.io/system-os_release.VERSION_ID"
 
 	labelOSReleaseID             = "feature.node.kubernetes.io/system-os_release.ID"
 	labelOSReleaseVersionIDMajor = "feature.node.kubernetes.io/system-os_release.VERSION_ID.major"
@@ -29,11 +23,10 @@ const (
 )
 
 type NodeVersion struct {
-	OSVersion      string                      `json:"OSVersion"`
-	OSMajor        string                      `json:"OSMajor"`
-	OSMajorMinor   string                      `json:"OSMajorMinor"`
-	ClusterVersion string                      `json:"clusterVersion"`
-	DriverToolkit  registry.DriverToolkitEntry `json:"driverToolkit"`
+	OSVersion      string `json:"OSVersion"`
+	OSMajor        string `json:"OSMajor"`
+	OSMajorMinor   string `json:"OSMajorMinor"`
+	ClusterVersion string `json:"clusterVersion"`
 }
 
 //go:generate mockgen -source=upgrade.go -package=upgrade -destination=mock_upgrade_api.go
@@ -61,21 +54,10 @@ func (ci *clusterInfo) GetClusterInfo(ctx context.Context, nodeList *corev1.Node
 
 	info, err := ci.nodeVersionInfo(nodeList)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get upgrade info: %w", err)
+		return nil, fmt.Errorf("failed to get node info: %w", err)
 	}
 
-	history, err := ci.cluster.VersionHistory(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("could not get version history: %w", err)
-	}
-
-	versions, err := ci.driverToolkitVersion(ctx, history, info)
-	if err != nil {
-		return nil, err
-	}
-
-	return versions, nil
-
+	return info, nil
 }
 
 func (ci *clusterInfo) nodeVersionInfo(nodeList *corev1.NodeList) (map[string]NodeVersion, error) {
@@ -87,7 +69,6 @@ func (ci *clusterInfo) nodeVersionInfo(nodeList *corev1.NodeList) (map[string]No
 	// one could easily add driver-kernel-versions for each node.
 	for _, node := range nodeList.Items {
 
-		var rhelVersion string
 		var kernelFullVersion string
 		var clusterVersion string
 
@@ -102,125 +83,10 @@ func (ci *clusterInfo) nodeVersionInfo(nodeList *corev1.NodeList) (map[string]No
 			return nil, fmt.Errorf("label %s not found is NFD running? Check node labels", labelOSReleaseVersionID)
 		}
 
-		if rhelVersion, found = labels[labelOSReleaseRHELVersion]; !found {
-			nodeOSrel := labels[labelOSReleaseID]
-			nodeOSmaj := labels[labelOSReleaseVersionIDMajor]
-			nodeOSmin := labels[labelOSReleaseVersionIDMinor]
-			info[kernelFullVersion] = NodeVersion{OSVersion: nodeOSmaj + "." + nodeOSmin, OSMajor: nodeOSrel + nodeOSmaj, OSMajorMinor: nodeOSrel + nodeOSmaj + "." + nodeOSmin, ClusterVersion: clusterVersion}
-		} else {
-			rhelMaj := rhelVersion[0:1]
-			info[kernelFullVersion] = NodeVersion{OSVersion: rhelVersion, OSMajor: "rhel" + rhelMaj, OSMajorMinor: "rhel" + rhelVersion, ClusterVersion: clusterVersion}
-		}
-	}
-
-	return info, nil
-}
-
-func (ci *clusterInfo) updateInfo(info map[string]NodeVersion, dtk registry.DriverToolkitEntry, imageURL string) (map[string]NodeVersion, error) {
-	dtk.ImageURL = imageURL
-	osDTK := dtk.OSVersion
-	// Assumes all nodes have the same architecture
-	runningArch := runtime.GOARCH
-	ci.log.Info("Runtime GOARCH is:", "runningArch", runningArch)
-	ci.log.Info("dtk.KernelFullVersion is:", "kernelVersion", dtk.KernelFullVersion)
-	switch runningArch {
-	case "amd64":
-		runningArch = "x86_64"
-	case "arm64":
-		runningArch = "aarch64"
-	}
-	if !strings.Contains(dtk.KernelFullVersion, runningArch) {
-		dtk.KernelFullVersion = dtk.KernelFullVersion + "." + runningArch
-		dtk.RTKernelFullVersion = dtk.RTKernelFullVersion + "." + runningArch
-		ci.log.Info("Updating version:", "dtk.KernelFullVersion", dtk.KernelFullVersion, "dtk.RTKernelFullVersion", dtk.RTKernelFullVersion)
-	}
-
-	match := false
-
-	if _, ok := info[dtk.KernelFullVersion]; ok {
-		osNFD := info[dtk.KernelFullVersion].OSVersion
-
-		if osNFD != osDTK {
-			return nil, fmt.Errorf("OSVersion mismatch NFD: %s vs. DTK: %s", osNFD, osDTK)
-		}
-
-		nodeVersion := info[dtk.KernelFullVersion]
-		nodeVersion.OSVersion = dtk.OSVersion
-		nodeVersion.DriverToolkit = dtk
-
-		info[dtk.KernelFullVersion] = nodeVersion
-		match = true
-	}
-
-	if _, ok := info[dtk.RTKernelFullVersion]; ok {
-		osNFD := info[dtk.RTKernelFullVersion].OSVersion
-
-		if osNFD != osDTK {
-			return nil, fmt.Errorf("OSVersion mismatch NFD: %s vs. DTK: %s", osNFD, osDTK)
-		}
-
-		nodeVersion := info[dtk.RTKernelFullVersion]
-		nodeVersion.OSVersion = dtk.OSVersion
-		nodeVersion.DriverToolkit = dtk
-
-		info[dtk.RTKernelFullVersion] = nodeVersion
-		match = true
-	}
-
-	if !match {
-		return nil, fmt.Errorf("DTK kernel not found running in the cluster. kernelFullVersion: %s. rtKernelFullVersion: %s", dtk.KernelFullVersion, dtk.RTKernelFullVersion)
-	}
-
-	return info, nil
-}
-
-func (ci *clusterInfo) driverToolkitVersion(ctx context.Context, entries []string, info map[string]NodeVersion) (map[string]NodeVersion, error) {
-
-	for _, entry := range entries {
-
-		ci.log.Info("History", "entry", entry)
-
-		var (
-			err   error
-			layer v1.Layer
-		)
-
-		layer, err = ci.registry.LastLayer(ctx, entry)
-		if err != nil {
-			return nil, err
-		}
-
-		if layer == nil {
-			continue
-		}
-		// For each entry we're fetching the cluster version and dtk URL
-		_, imageURL, err := ci.registry.ReleaseManifests(layer)
-		if err != nil {
-			return nil, fmt.Errorf("could not extract version from payload: %w", err)
-		}
-
-		if imageURL == "" {
-			utils.WarnOnError(errors.New("No DTK image found, DTK cannot be used in a Build"))
-			return info, nil
-		}
-
-		if layer, err = ci.registry.LastLayer(ctx, imageURL); layer == nil {
-			return nil, fmt.Errorf("cannot extract last layer for DTK from %s: %w", imageURL, err)
-		}
-
-		dtk, err := ci.registry.ExtractToolkitRelease(layer)
-		if err != nil {
-			return nil, err
-		}
-
-		// info has the kernels that are currently "running" on the cluster
-		// we're going only to update the struct with DTK information on
-		// running kernels and not on all that are found.
-		// We could have many entries with DTKs that are from an old update
-		// The objects that are kernel affine should only be replicated
-		// for valid kernels.
-		return ci.updateInfo(info, dtk, imageURL)
-
+		nodeOSrel := labels[labelOSReleaseID]
+		nodeOSmaj := labels[labelOSReleaseVersionIDMajor]
+		nodeOSmin := labels[labelOSReleaseVersionIDMinor]
+		info[kernelFullVersion] = NodeVersion{OSVersion: nodeOSmaj + "." + nodeOSmin, OSMajor: nodeOSrel + nodeOSmaj, OSMajorMinor: nodeOSrel + nodeOSmaj + "." + nodeOSmin, ClusterVersion: clusterVersion}
 	}
 
 	return info, nil


### PR DESCRIPTION
This PR mainly adjust the code that is responsible for preparing NodeVersion
map.
1) remove data gathering from ClusterVersion
2) remove data gathering from DTK
3) NodeVersion should contain only data taken from label not related to RCHOS
4) update unit-test