### PR TITLE
Speed up operator image rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 RUN ["go",  "mod", "download"]
 
-COPY Makefile.specialresource.mk Makefile.specialresource.mk
-COPY Makefile.helm.mk Makefile.helm.mk
-COPY Makefile.helper.mk Makefile.helper.mk
-COPY Makefile Makefile
+COPY Makefile* .
 RUN ["make", "controller-gen"]
 
 COPY cmd/ cmd/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 RUN ["go",  "mod", "download"]
 
-COPY Makefile* .
+COPY Makefile* ./
 RUN ["make", "controller-gen"]
 
 COPY cmd/ cmd/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,11 @@ COPY Makefile.helper.mk Makefile.helper.mk
 COPY Makefile Makefile
 RUN ["make", "controller-gen"]
 
-COPY charts/ charts/
-RUN ["make", "helm-repo-index"]
-
 COPY cmd/ cmd/
 RUN ["make", "helm-plugins/cm-getter/cm-getter"]
+
+COPY charts/ charts/
+RUN ["make", "helm-repo-index"]
 
 COPY hack/ hack/
 COPY helm-plugins/ helm-plugins/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,28 +3,33 @@ FROM golang:1.17-bullseye AS builder
 
 WORKDIR /workspace
 
-# Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
+RUN ["go",  "mod", "download"]
 
-COPY hack/ hack/
-COPY helm-plugins/ helm-plugins/
 COPY Makefile.specialresource.mk Makefile.specialresource.mk
 COPY Makefile.helm.mk Makefile.helm.mk
 COPY Makefile.helper.mk Makefile.helper.mk
 COPY Makefile Makefile
+RUN ["make", "controller-gen"]
+
+COPY charts/ charts/
+RUN ["make", "helm-repo-index"]
+
+COPY cmd/ cmd/
+RUN ["make", "helm-plugins/cm-getter/cm-getter"]
+
+COPY hack/ hack/
+COPY helm-plugins/ helm-plugins/
 COPY scripts/ scripts/
 
-# Copy the go source
 COPY main.go main.go
 COPY api/ api/
-COPY cmd/ cmd/
 COPY controllers/ controllers/
 COPY internal/ internal/
 COPY pkg/ pkg/
-COPY charts/ charts/
 
-RUN ["make", "helm-repo-index", "manager", "helm-plugins/cm-getter/cm-getter"]
+RUN ["make", "manager"]
 
 FROM debian:bullseye-slim
 
@@ -34,13 +39,12 @@ RUN ["apt", "install", "-y", "ca-certificates"]
 WORKDIR /
 
 ENV HELM_PLUGINS /opt/helm-plugins
-
-COPY --from=builder /workspace/manager /manager
-COPY --from=builder /workspace/helm-plugins ${HELM_PLUGINS}
-COPY --from=builder /workspace/build/charts /charts
-
 RUN useradd  -r -u 499 nonroot
 RUN getent group nonroot || groupadd -o -g 499 nonroot
+
+COPY --from=builder /workspace/helm-plugins ${HELM_PLUGINS}
+COPY --from=builder /workspace/build/charts /charts
+COPY --from=builder /workspace/manager /manager
 
 ENTRYPOINT ["/manager"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM golang:1.17-bullseye AS builder
 
 WORKDIR /workspace
 
+# Following sections are ordered by expected chance of being changed in daily developer's work:
+# go.mod is expected to change less frequently than the SRO's code.
+# This approach leverages layer caching to speed up rebuilds.
+
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN ["go",  "mod", "download"]


### PR DESCRIPTION
Change reorders instructions `Dockerfile` to leverage Docker/Podman's layer caching mechanisms.

Instructions are reordered based on expected chance of getting changed in daily developer's work.
For example Go modules are least likely to change, so they're fetched first with a significant chance of not being invalidated until upgrade of Go dependencies.