### PR TITLE
check GetNodesByLabels() output for empty sets and return an error

### DIFF
--- a/controllers/runtime.go
+++ b/controllers/runtime.go
@@ -88,6 +88,10 @@ func getRuntimeInformation(ctx context.Context, r *SpecialResourceReconciler) er
 	if err != nil {
 		return fmt.Errorf("failed to get nodes list during getRuntimeInformation: %w", err)
 	}
+	// a zero length nodelist does not return an error so needs to be checked for separately
+	if len(nodeList.Items) == 0 {
+		return fmt.Errorf("no nodes matched the supplied node selector: %v", r.specialresource.Spec.NodeSelector)
+	}
 
 	RunInfo.OperatingSystemMajor, RunInfo.OperatingSystemMajorMinor, RunInfo.OperatingSystemDecimal, err = r.Cluster.OperatingSystem(nodeList)
 	if err != nil {

--- a/controllers/upgrade.go
+++ b/controllers/upgrade.go
@@ -18,6 +18,9 @@ func SpecialResourceUpgrade(ctx context.Context, r *SpecialResourceReconciler) (
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get nodes: %w", err)
 	}
+	if len(nodeList.Items) == 0 {
+		return ctrl.Result{}, fmt.Errorf("no nodes matched the given node selector: %v", r.specialresource.Spec.NodeSelector)
+	}
 
 	RunInfo.ClusterUpgradeInfo, err = r.ClusterInfo.GetClusterInfo(ctx, nodeList)
 	if err != nil {


### PR DESCRIPTION
If you set the nodeSelector field within a specialresource to something that matches no nodes you can induce the controller to panic with the below error message. This patch simply checks the node list and if it is zero length returns an error message before the nodelist is used.. 

A panic is caused because the the GetNodesByLabels looks for nodes that match the nodeselector,
(https://github.com/openshift/special-resource-operator/blob/master/pkg/runtime/runtime.go#L124 ) but if nothing matches it returns an empty list, this empty list is passed to FullVersion  (https://github.com/openshift/special-resource-operator/blob/master/pkg/runtime/runtime.go#L134) to retrieve the kernel version label which returns an empty string as the version for an empty nodelist,  and this kernel version is then parsed into an array on the "." character to give X.Y.Z fields (https://github.com/openshift/special-resource-operator/blob/master/pkg/kernel/kernel.go#L156), because the kernelversion is an empty string this leads to a zero length array, and then on the next line when the elements of this array are accessed it causes an array out of bounds error and a panic : 


panic: runtime error: index out of range [1] with length 1

goroutine 584 [running]:
github.com/openshift-psap/special-resource-operator/pkg/kernel.(*kernelData).PatchVersion(0xc000844540, {0x0, 0x0})
        /workspace/pkg/kernel/kernel.go:162 +0x15b
github.com/openshift-psap/special-resource-operator/controllers.getRuntimeInformation({0x2cb4648, 0xc0056d11d0}, 0xc00060c800)
        /workspace/controllers/runtime.go:102 +0x24f
github.com/openshift-psap/special-resource-operator/controllers.ReconcileSpecialResourceChart({_, _}, _, {{{0x250f651, 0xf}, {0xc00612f878, 0x18}}, {{0xc005ab5d30, 0xb}, {0x0, ...}, ...}, ...}, ...)
        /workspace/controllers/specialresource.go:214 +0x1f4
github.com/openshift-psap/special-resource-operator/controllers.SpecialResourcesReconcile({0x2cb4648, 0xc0056d11d0}, 0xc00060c800, {{{0x0, 0x4}, {0xc00594d630, 0xc002f91cf8}}})
        /workspace/controllers/specialresource.go:155 +0x9f3
github.com/openshift-psap/special-resource-operator/controllers.(*SpecialResourceReconciler).Reconcile(0xc00060c800, {0x2cb4648, 0xc0056d11d0}, {{{0x0, 0x2833640}, {0xc00594d630, 0xc0056b6d80}}})
        /workspace/controllers/specialresource_controller.go:102 +0x1ff
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc00068e000, {0x2cb4648, 0xc0056d1140}, {{{0x0, 0x2833640}, {0xc00594d630, 0xc00053c9c0}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:114 +0x222
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00068e000, {0x2cb45a0, 0xc0002f8a40}, {0x27864e0, 0xc0051ace20})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:311 +0x2f})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:266 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:223 +0x354
