### PR TITLE
Adding missing packages for linting.

### DIFF
--- a/scripts/test-infra/lint.sh
+++ b/scripts/test-infra/lint.sh
@@ -2,4 +2,7 @@
 
 set -e
 
+apt update -y
+apt install shellcheck
+
 make lint


### PR DESCRIPTION
Until now, in OCP CI, we were building a custom container image to
contain all the required packages and used it in some tests.

In test-infra, we can use the golang docker image as a base image so the
flow is much simpler and we can just install the missing package.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>