### PR TITLE
Add an end-to-end test with a pre-built container 

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,14 +10,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install curl
-        run: |
-          sudo apt -y update
-          sudo apt -y install curl
-
       - name: Download and install minikube
         run: |
-          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
+          wget https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
           sudo dpkg -i ./minikube_latest_amd64.deb
 
       - name: Start minikube and wait until minikube's CoreDNS is available
@@ -27,9 +22,6 @@ jobs:
 
       - name: Build SRO
         run: minikube image build -t sro:local .
-
-      - name: Install kubectl
-        uses: azure/setup-kubectl@v2.0
 
       - name: Install NFD
         run: kubectl apply -k https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.10.1
@@ -79,6 +71,102 @@ jobs:
       - name: Check that the ClusterRoleBinding gets removed
         run: kubectl wait --for=delete clusterrolebinding/ci-priv-esc
         timeout-minutes: 1
+
+      - name: Get all operator logs
+        run: kubectl logs deployment.apps/special-resource-controller-manager -n special-resource-operator
+        if: ${{ always() }}
+
+  e2e:
+    name: Prebuilt kernel module
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Save the kernel version
+        run: echo "KERNEL_VERSION=$(uname -r)" >> $GITHUB_ENV
+
+      - name: Build the kernel module
+        run: make KERNEL_SRC_DIR="/usr/src/linux-headers-${KERNEL_VERSION}"
+        working-directory: ci/sro-kmod
+
+      - name: Download and install minikube
+        run: |
+          wget https://storage.googleapis.com/minikube/releases/latest/minikube_latest_amd64.deb
+          sudo dpkg -i ./minikube_latest_amd64.deb
+
+      - name: Start minikube and wait until CoreDNS is available
+        run: |
+          minikube start --driver=docker
+          kubectl wait --for=condition=available deployment coredns -n kube-system
+
+      - name: Build sro-kmod
+        run: minikube image build -t sro-kmod:local --build-opt build-arg=KERNEL_VERSION=${KERNEL_VERSION} ci/sro-kmod
+
+      - name: Build SRO
+        run: minikube image build -t sro:local .
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.6
+
+      - name: Install NFD
+        run: kubectl apply -k https://github.com/kubernetes-sigs/node-feature-discovery/deployment/overlays/default?ref=v0.10.1
+
+      - name: Deploy SRO
+        run: make deploy
+        env:
+          IMG: sro:local
+
+      - name: Set the SRO manager's pull policy to Never
+        run: kubectl patch deployments.apps -n special-resource-operator special-resource-controller-manager --patch-file ci/patch-sro-manager-pullpolicy.yml
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v1
+
+      - name: Create a ConfigMap containing the test chart
+        run: scripts/make-cm-recipe ci/chart-sro-ci sro-ci
+
+      - name: Check that the sro_ci module is not loaded on the node
+        run: |
+          if minikube ssh -- lsmod | grep sro_ci; then
+            echo "Unexpected lsmod output - the module should not be loaded"
+            exit 1
+          fi
+
+      - name: Create the SpecialResource
+        run: kubectl apply -f ci/sr-sro-ci.yml
+
+      - name: Check that the module gets loaded on the node
+        run: |
+          until minikube ssh -- lsmod | grep sro_ci; do
+            sleep 3
+          done
+        timeout-minutes: 1
+
+      - name: Remove the SpecialResource
+        run: kubectl delete -f ci/sr-sro-ci.yml
+
+      - name: Check that the module gets unloaded from the node
+        run: |
+          until ! minikube ssh -- lsmod | grep sro_ci; do
+            sleep 3
+          done
+        timeout-minutes: 1
+
+      - name: Describe the DaemonSet
+        run: kubectl describe daemonset -n sro-ci sro-ci-driver-container
+        continue-on-error: true # if the job succeeded, there might not be an sro-ci namespace anymore
+        if: ${{ always() }}
+
+      - name: Describe the Pod
+        run: kubectl describe pod -n sro-ci sro-ci-driver-container
+        continue-on-error: true # if the job succeeded, there might not be an sro-ci namespace anymore
+        if: ${{ always() }}
+
+      - name: Collect dmesg
+        run: sudo dmesg
+        if: ${{ always() }}
 
       - name: Get all operator logs
         run: kubectl logs deployment.apps/special-resource-controller-manager -n special-resource-operator

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,5 @@ RUN getent group nonroot || groupadd -o -g 499 nonroot
 
 ENTRYPOINT ["/manager"]
 
-LABEL io.k8s.display-name="OpenShift Special Resource Operator" \
-      io.k8s.description="This is a component of OpenShift and manages the lifecycle of out-of-tree drivers with enablement stack."
+LABEL io.k8s.display-name="Special Resource Operator" \
+      io.k8s.description="SRO manages the lifecycle of out-of-tree drivers with enablement stack."

--- a/ci/chart-sro-ci/Chart.yaml
+++ b/ci/chart-sro-ci/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: sro-ci
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/ci/chart-sro-ci/templates/1000-driver-container.yaml
+++ b/ci/chart-sro-ci/templates/1000-driver-container.yaml
@@ -1,0 +1,36 @@
+{{- $appName := printf "%s-driver-container" .Release.Name }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: {{ $appName }}
+  name: {{ $appName }}
+  annotations:
+    specialresource.openshift.io/wait: "true"
+    specialresource.openshift.io/state: "driver-container"
+    specialresource.openshift.io/driver-container-vendor: sro-ci
+    specialresource.openshift.io/kernel-affine: "true"
+spec:
+  selector:
+    matchLabels:
+      app: {{ $appName }}
+  template:
+    metadata:
+      labels:
+        app: {{ $appName }}
+    spec:
+      containers:
+        - image: {{ .Values.image.name }}:{{ .Values.image.tag }}
+          name: modprobe
+          command: [sleep, infinity]
+          lifecycle:
+            postStart:
+              exec:
+                command: [modprobe, -v, sro_ci]
+            preStop:
+              exec:
+                command: [modprobe, -vr, sro_ci]
+          securityContext:
+            capabilities:
+              add: [SYS_MODULE]

--- a/ci/chart-sro-ci/values.yaml
+++ b/ci/chart-sro-ci/values.yaml
@@ -1,0 +1,4 @@
+---
+image:
+  name: sro-kmod
+  tag: local

--- a/ci/sr-sro-ci.yml
+++ b/ci/sr-sro-ci.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: sro.openshift.io/v1beta1
+kind: SpecialResource
+metadata:
+  name: sro-ci
+spec:
+  namespace: sro-ci
+  chart:
+    name: sro-ci
+    version: 0.0.1
+    repository:
+      name: sro-ci
+      url: cm://default/sro-ci

--- a/ci/sro-kmod/Dockerfile
+++ b/ci/sro-kmod/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine
+
+RUN ["apk", "add", "kmod"]
+
+ARG KERNEL_VERSION
+
+RUN mkdir -p /lib/modules/${KERNEL_VERSION}
+
+COPY sro_ci.ko /lib/modules/${KERNEL_VERSION}/
+
+RUN ["depmod"]

--- a/ci/sro-kmod/Makefile
+++ b/ci/sro-kmod/Makefile
@@ -1,0 +1,8 @@
+KERNEL_SRC_DIR =
+
+ccflags-y += -I$(KERNEL_SRC_DIR)/include
+obj-m += sro_ci.o
+
+all:
+	make -C $(KERNEL_SRC_DIR) $(MAKE_OPTS) M=$(PWD) modules
+

--- a/ci/sro-kmod/sro_ci.c
+++ b/ci/sro-kmod/sro_ci.c
@@ -1,0 +1,20 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Quentin Barrand");
+MODULE_DESCRIPTION("A simple kernel module for SRO CI");
+MODULE_VERSION("0.01");
+
+static int __init sro_ci_init(void) {
+    printk(KERN_INFO "Hello, World!\n");
+    return 0;
+}
+
+static void __exit sro_ci_exit(void) {
+    printk(KERN_INFO "Goodbye, World!\n");
+}
+
+module_init(sro_ci_init);
+module_exit(sro_ci_exit);


### PR DESCRIPTION
This end-to-end test runs the following steps:
1. Build a very simple `sro_ci` kernel module that does nothing. This is made possible by the Ubuntu runners having the kernel headers already installed for the version that they are running;
2. Create a Kubernetes cluster using minikube and its `docker` driver. The runners already run a Docker daemon, so there is no additional dependency;
3. Build an Alpine-based DriverContainer image containing the module built at step 1; 
4. Build the SRO container image;
5. Install NFD;
6. Deploy SRO. `make deploy` specifies the `Always` `imagePullPolicy`, so we have to patch it to use the image we built at step 4 that is already in minikube;
7. Create an `sro-ci` SRO recipe (Helm Chart) in a ConfigMap that runs the DriverContainer image in a DaemonSet;
8. Install a `SpecialResource` CR that installs the `sro-ci` recipe;
9. Verify that the `sro_ci` gets loaded on the node within one minute;
10. Delete the `SpecialResource`, which should uninstall the recipe and remove the DriverContainer;
11. Verify that `sro_ci` gets unloaded from the node within one minute.

A few remarks:
- in most cases, the DriverContainer pod will only require `CAP_SYS_MODULE` instead of full privileges; this is what this test case specifies;
- the DriverContainer uses [container lifecyle hooks](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/) to unload the module when it exits;
- this flow only works because the runners have the kernel headers installed. As we've seen, Ubuntu only offers the latest headers in their repos; if we had to download the `.deb` manually from launchpad.net, things would be much more complex;
- in other environments (e.g. Prow) we will probably not be able to run workloads with `CAP_SYS_MODULE`, which will make this flow fail. The solution there will likely involve spawning a VM somewhere on which we can run a fully-privileged minikube.

/cc @pacevedom @yevgeny-shnaidman @ybettan 