### PR TITLE
Upgrade to a version of golangci-lint that does not crash on 1.18

### DIFF
--- a/Makefile.helper.mk
+++ b/Makefile.helper.mk
@@ -42,7 +42,7 @@ kube-linter:
 # Download golangci-lint locally if necessary
 GOLANGCILINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
-	$(call go-get-tool,$(GOLANGCILINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0)
+	$(call go-get-tool,$(GOLANGCILINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2)
 
 # Additional bundle options for ART
 DEFAULT_CHANNEL="4.9"


### PR DESCRIPTION
Although not all linters are supported, at least golangci-lint v 1.45.2 does not crash when built with Go 1.18.
This is required to merge https://github.com/openshift/release/pull/27638.

/cc @ybettan